### PR TITLE
Updated OS support for DuoS and Mars

### DIFF
--- a/Duo_S/BuildRoot/README.md
+++ b/Duo_S/BuildRoot/README.md
@@ -78,7 +78,7 @@ PRETTY_NAME="Buildroot 2021.05"
 
 Screen recording (From flashing image to login):
 
-[!bilibili](https://www.bilibili.com/video/BV1kCU6Y1ECg/?vd_source=1291fcfaefa3ea5589519340cf2ed80c)(https://www.bilibili.com/video/BV1kCU6Y1ECg/?vd_source=1291fcfaefa3ea5589519340cf2ed80c)
+[!asciinema](https://asciinema.org/a/y74COq4Da80mjhqZygoL7i97x)(https://asciinema.org/a/y74COq4Da80mjhqZygoL7i97x)
 
 ## Test Criteria
 

--- a/Duo_S/BuildRoot/README.md
+++ b/Duo_S/BuildRoot/README.md
@@ -78,7 +78,7 @@ PRETTY_NAME="Buildroot 2021.05"
 
 Screen recording (From flashing image to login):
 
-[!asciinema](https://asciinema.org/a/y74COq4Da80mjhqZygoL7i97x)(https://asciinema.org/a/y74COq4Da80mjhqZygoL7i97x)
+[![asciinema](https://asciinema.org/a/y74COq4Da80mjhqZygoL7i97x)](https://asciinema.org/a/y74COq4Da80mjhqZygoL7i97x)
 
 ## Test Criteria
 

--- a/Duo_S/BuildRoot/README.md
+++ b/Duo_S/BuildRoot/README.md
@@ -4,7 +4,7 @@ sys_ver: null
 sys_var: null
 
 status: basic
-last_update: 2024-06-21
+last_update: 2024-11-17
 ---
 
 # BuildRoot Milk-V Duo S Test Report
@@ -13,7 +13,7 @@ last_update: 2024-06-21
 
 ### Operating System Information
 
-- System Version: Duo-V1.1.0
+- System Version: Duo-V1.1.3
 - Download Link: https://github.com/milkv-duo/duo-buildroot-sdk/releases
 - Reference Installation Document: https://github.com/milkv-duo/duo-buildroot-sdk
 
@@ -32,17 +32,20 @@ last_update: 2024-06-21
 
 Install the [`ruyi`](https://github.com/ruyisdk/ruyi) package manager, run `ruyi device provision`, and follow the prompts.
 
+### using `balenaEtcher` to Flash Image to microSD Card
+Install[`balennaEtcher`],use open source tool balenaEtcher for flashing
+
 ### Logging into the System
 
 Log into the system via the serial port.
 
 ## Expected Results
 
-The system should boot normally and allow login via the onboard serial port.
+The system should boot normally and allow login via the onboard serial port and ssh.
 
 ## Actual Results
 
-The system booted successfully and login via the onboard serial port was also successful.
+The system booted successfully and login via the onboard serial port and ssh was also successful.
 
 ### Boot Information
 
@@ -75,7 +78,7 @@ PRETTY_NAME="Buildroot 2021.05"
 
 Screen recording (From flashing image to login):
 
-[![asciicast](https://asciinema.org/a/Zbt8azPsJFYLWOYCKgPNrt9S7.svg)](https://asciinema.org/a/Zbt8azPsJFYLWOYCKgPNrt9S7)
+[!bilibili](https://www.bilibili.com/video/BV1kCU6Y1ECg/?vd_source=1291fcfaefa3ea5589519340cf2ed80c)(https://www.bilibili.com/video/BV1kCU6Y1ECg/?vd_source=1291fcfaefa3ea5589519340cf2ed80c)
 
 ## Test Criteria
 

--- a/Duo_S/BuildRoot/README.md
+++ b/Duo_S/BuildRoot/README.md
@@ -32,8 +32,8 @@ last_update: 2024-11-17
 
 Install the [`ruyi`](https://github.com/ruyisdk/ruyi) package manager, run `ruyi device provision`, and follow the prompts.
 
-### using `balenaEtcher` to Flash Image to microSD Card
-Install[`balennaEtcher`],use open source tool balenaEtcher for flashing
+### Using `balenaEtcher` to flash image to microSD Card
+Install `balennaEtcher`, the open source tool for flashing.
 
 ### Logging into the System
 

--- a/Duo_S/BuildRoot/README_zh.md
+++ b/Duo_S/BuildRoot/README_zh.md
@@ -70,7 +70,7 @@ PRETTY_NAME="Buildroot 2021.05"
 
 屏幕录像（从刷写镜像到登录系统）：
 
-[!asciinema](https://asciinema.org/a/y74COq4Da80mjhqZygoL7i97x)(https://asciinema.org/a/y74COq4Da80mjhqZygoL7i97x)
+[![asciinema](https://asciinema.org/a/y74COq4Da80mjhqZygoL7i97x)](https://asciinema.org/a/y74COq4Da80mjhqZygoL7i97x)
 
 ## 测试判定标准
 

--- a/Duo_S/BuildRoot/README_zh.md
+++ b/Duo_S/BuildRoot/README_zh.md
@@ -20,12 +20,12 @@
 
 ## 安装步骤
 
-### 1 使用 `ruyi` CLI 刷写镜像到 microSD 卡
+###  使用 `ruyi` CLI 刷写镜像到 microSD 卡
 
 安装 [`ruyi`](https://github.com/ruyisdk/ruyi) 包管理器，运行 `ruyi device provision` 并按提示操作。
 
-### 2 使用 `balenaEtcher` 刷写镜像到 microSD 卡
-安装[`balennaEtcher`] 使用开源跨平台工具 balenaEtcher 进行刷写
+###  使用 `balenaEtcher` 刷写镜像到 microSD 卡
+安装开源跨平台工具 `balenaEtcher` 进行刷写。
 
 ### 登录系统
 

--- a/Duo_S/BuildRoot/README_zh.md
+++ b/Duo_S/BuildRoot/README_zh.md
@@ -4,7 +4,7 @@
 
 ### 操作系统信息
 
-- 系统版本：Duo-V1.1.0
+- 系统版本：Duo-V1.1.3
 - 下载链接：https://github.com/milkv-duo/duo-buildroot-sdk/releases
 - 参考安装文档：https://github.com/milkv-duo/duo-buildroot-sdk
 
@@ -20,9 +20,12 @@
 
 ## 安装步骤
 
-### 使用 `ruyi` CLI 刷写镜像到 microSD 卡
+### 1 使用 `ruyi` CLI 刷写镜像到 microSD 卡
 
 安装 [`ruyi`](https://github.com/ruyisdk/ruyi) 包管理器，运行 `ruyi device provision` 并按提示操作。
+
+### 2 使用 `balenaEtcher` 刷写镜像到 microSD 卡
+安装[`balennaEtcher`] 使用开源跨平台工具 balenaEtcher 进行刷写
 
 ### 登录系统
 
@@ -30,11 +33,11 @@
 
 ## 预期结果
 
-系统正常启动，能够通过板载串口登录。
+系统正常启动，能够通过板载串口和ssh登录。
 
 ## 实际结果
 
-系统正常启动，成功通过板载串口登录。
+系统正常启动，成功通过板载串口与ssh登录。
 
 ### 启动信息
 
@@ -67,7 +70,7 @@ PRETTY_NAME="Buildroot 2021.05"
 
 屏幕录像（从刷写镜像到登录系统）：
 
-[![asciicast](https://asciinema.org/a/Zbt8azPsJFYLWOYCKgPNrt9S7.svg)](https://asciinema.org/a/Zbt8azPsJFYLWOYCKgPNrt9S7)
+[!bilibili](https://www.bilibili.com/video/BV1kCU6Y1ECg/?vd_source=1291fcfaefa3ea5589519340cf2ed80c)(https://www.bilibili.com/video/BV1kCU6Y1ECg/?vd_source=1291fcfaefa3ea5589519340cf2ed80c)
 
 ## 测试判定标准
 

--- a/Duo_S/BuildRoot/README_zh.md
+++ b/Duo_S/BuildRoot/README_zh.md
@@ -70,7 +70,7 @@ PRETTY_NAME="Buildroot 2021.05"
 
 屏幕录像（从刷写镜像到登录系统）：
 
-[!bilibili](https://www.bilibili.com/video/BV1kCU6Y1ECg/?vd_source=1291fcfaefa3ea5589519340cf2ed80c)(https://www.bilibili.com/video/BV1kCU6Y1ECg/?vd_source=1291fcfaefa3ea5589519340cf2ed80c)
+[!asciinema](https://asciinema.org/a/y74COq4Da80mjhqZygoL7i97x)(https://asciinema.org/a/y74COq4Da80mjhqZygoL7i97x)
 
 ## 测试判定标准
 

--- a/Duo_S/Fedora/README.md
+++ b/Duo_S/Fedora/README.md
@@ -1,0 +1,68 @@
+---
+sys: fedora
+sys_ver: 41
+sys_var: null
+
+status: basic
+last_update: 2024-11-24
+---
+
+# Fedora 41 Milk-V DuoS Test Report
+
+## Test Environment
+
+### Operating System Information
+
+- System Version: Fedora 41
+- Download Link: https://mirror.iscas.ac.cn/fedora-riscv/dl/Milk-V/DuoS/images/latest/
+- Reference Installation Document: https://fedoraproject.org/wiki/Architectures/RISC-V/Installing
+
+> Note: This image is provided by community developers and is not an official image.
+
+### Hardware Information
+
+- Milk-V Duo S
+- A USB power adapter
+- A USB-A to C or USB-C to C cable
+- A microSD card
+- A USB to UART debugger (e.g., CH340, CH341, FT2232, etc.)
+- Three DuPont wires
+- The Milk-V Duo has pre-soldered pin headers required for debugging
+- Optional: Milk-V Duo IOB (baseboard)
+
+## Installation Steps
+
+### Flashing the Image to microSD Card Using `dd`
+
+```shell
+zcat milkv-duos-fedora-minimal.img.gz | sudo dd of=/dev/sda bs=4M iflag=fullblock status=progress 
+```
+
+### Logging into the System
+
+Log into the system via the serial port.
+
+Username: `root`
+Password: `riscv`
+
+## Expected Results
+
+The system should boot normally and allow login via the serial port.
+
+## Actual Results
+
+The system booted successfully and login via the onboard serial port was also successful.
+
+Screen recording of the boot process:
+
+[![asciicast](https://asciinema.org/a/5dJWtw2u1EB1f78SyIeFJ4Jqd)](https://asciinema.org/a/5dJWtw2u1EB1f78SyIeFJ4Jqd)
+
+## Test Criteria
+
+Successful: The actual result matches the expected result.
+
+Failed: The actual result does not match the expected result.
+
+## Test Conclusion
+
+Test successful.

--- a/Duo_S/Fedora/README_zh.md
+++ b/Duo_S/Fedora/README_zh.md
@@ -1,0 +1,59 @@
+# Fedora 41 Milk-V Duo 测试报告
+
+## 测试环境
+
+### 操作系统信息
+
+- 系统版本：Fedora 41
+- 下载链接：https://mirror.iscas.ac.cn/fedora-riscv/dl/Milk-V/DuoS/images/latest/
+- 参考安装文档：https://fedoraproject.org/wiki/Architectures/RISC-V/Installing
+
+> Note: 此镜像为社区开发者提供，非官方镜像。
+
+### 硬件信息
+
+- Milk-V Duo S
+- USB 电源适配器一个
+- USB-A to C 或 USB C to C 线缆一条
+- microSD 卡一张
+- USB to UART 调试器一个（如：CH340, CH341, FT2232 等）
+- 杜邦线三根
+- Milk-V Duo 本体上预先焊接好调试所需的排针
+- 可选：Milk-V Duo IOB（底板）
+
+## 安装步骤
+
+### 使用 `dd` 刷写镜像到 microSD 卡
+
+```shell
+zcat milkv-duos-fedora-minimal.img.gz | sudo dd of=/dev/sda bs=4M iflag=fullblock status=progress 
+```
+
+### 登录系统
+
+通过串口登录系统。
+
+用户名：`root`
+密码：`riscv`
+
+## 预期结果
+
+系统正常启动，能够通过串口登录。
+
+## 实际结果
+
+系统正常启动，成功通过板载串口登录。
+
+启动流程屏幕录像：
+
+[![asciicast](https://asciinema.org/a/5dJWtw2u1EB1f78SyIeFJ4Jqd)](https://asciinema.org/a/5dJWtw2u1EB1f78SyIeFJ4Jqd)
+
+## 测试判定标准
+
+测试成功：实际结果与预期结果相符。
+
+测试失败：实际结果与预期结果不符。
+
+## 测试结论
+
+测试成功。

--- a/Duo_S/NuttX/README.md
+++ b/Duo_S/NuttX/README.md
@@ -21,13 +21,17 @@ last_update: 2024-11-16
 
 ### Hardware Information
 
+Hardware Information
+
 - Milk-V Duo S (512M, SG2000)
-- A USB-A to C or USB C to C cable to power the development board
-- A microSD card for booting
-- A USB card reader for microSD burning
-- A USB to UART debugger (such as: CP2102, FT2232, etc., garbled characters will appear when using the CH340/341 series, which is an expected phenomenon)
-- Three Dupont lines for uart interface
-- Network cabling for optical fiber access (TFTP Boot cannot use USB network)
+- A USB Power Adapter
+- A USB-A to C or USB C to C cable for powering the development board
+- A microSD card
+- A USB card reader
+- A USB to UART Debugger (e.g., CP2102, FT2232, etc. Be aware that WCH CH340/341 series will cause garbled text output, DO NOT USE)
+- Three DuPont wires
+- Ethernet access for TFTP Boot
+
 
 
 

--- a/Duo_S/NuttX/README.md
+++ b/Duo_S/NuttX/README.md
@@ -216,7 +216,7 @@ nsh>
 
 Screen recording:
 
-[!bilibili](https://www.bilibili.com/video/BV1RMUeYjELe/?spm_id_from=333.999.0.0)
+[!asciinema](https://asciinema.org/a/Eai0QwU5y9USbr3FsYq7L1Mxf)(https://asciinema.org/a/Eai0QwU5y9USbr3FsYq7L1Mxf)
 
 ## Test Criteria
 

--- a/Duo_S/NuttX/README.md
+++ b/Duo_S/NuttX/README.md
@@ -22,13 +22,14 @@ last_update: 2024-06-21
 ### Hardware Information
 
 - Milk-V Duo S (512M, SG2000)
-- A USB Power Adapter
-- A USB-A to C or USB C to C cable for powering the development board
-- A microSD card
-- A USB card reader
-- A USB to UART Debugger (e.g., CP2102, FT2232, etc. Be aware that WCH CH340/341 series will cause garbled text output, DO NOT USE)
-- Three DuPont wires
-- Ethernet access for TFTP Boot
+- A USB-A to C or USB C to C cable to power the development board
+- A microSD card for booting
+- A USB card reader for microSD burning
+- A USB to UART debugger (such as: CP2102, FT2232, etc., garbled characters will appear when using the CH340/341 series, which is an expected phenomenon)
+- Three Dupont lines for uart interface
+- Network cabling for optical fiber access (TFTP Boot cannot use USB network)
+
+
 
 ## Installation Steps
 
@@ -102,6 +103,10 @@ cd nuttx
 tools/configure.sh milkv_duos:nsh
 make -j$(nproc)
 ```
+
+If you encounter file loss during the build process, you can configure options through menuconfig
+- Select whether to use the math library and its path in (Top) → Library Routines → Select math library
+- Select whether to enable llvm in (Top) → Library Routines → Builtin libclang_rt.profile
 
 Then, build the file system:
 ```bash
@@ -207,11 +212,7 @@ nsh>
 
 Screen recording:
 
-Part 1:
-[![asciicast](https://asciinema.org/a/8wvErVrySR04Ri18rPJ99qai9.svg)](https://asciinema.org/a/8wvErVrySR04Ri18rPJ99qai9)
-
-Part 2:
-[![asciicast](https://asciinema.org/a/loBvsK69TBtZmicjdzqHX2B9z.svg)](https://asciinema.org/a/loBvsK69TBtZmicjdzqHX2B9z)
+[!bilibili](https://www.bilibili.com/video/BV1RMUeYjELe/?spm_id_from=333.999.0.0)
 
 ## Test Criteria
 

--- a/Duo_S/NuttX/README.md
+++ b/Duo_S/NuttX/README.md
@@ -216,7 +216,7 @@ nsh>
 
 Screen recording:
 
-[!asciinema](https://asciinema.org/a/Eai0QwU5y9USbr3FsYq7L1Mxf)(https://asciinema.org/a/Eai0QwU5y9USbr3FsYq7L1Mxf)
+[![asciinema](https://asciinema.org/a/Eai0QwU5y9USbr3FsYq7L1Mxf)](https://asciinema.org/a/Eai0QwU5y9USbr3FsYq7L1Mxf)
 
 ## Test Criteria
 

--- a/Duo_S/NuttX/README.md
+++ b/Duo_S/NuttX/README.md
@@ -4,7 +4,7 @@ sys_ver: null
 sys_var: null
 
 status: basic
-last_update: 2024-06-21
+last_update: 2024-11-16
 ---
 
 # NuttX on Milk-V Duo S Test Report

--- a/Duo_S/NuttX/README_zh.md
+++ b/Duo_S/NuttX/README_zh.md
@@ -4,10 +4,10 @@
 
 ### 操作系统信息
 
-- Debian Linux 镜像 + U-Boot:https：//github.com/Fishwaldo/sophgo-sg200x-debian/releases
-- 工具链:xPack https：//github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases
-- dtb 文件：https：//github.com/lupyuen2/wip-nuttx/releases/download/sg2000-1/cv181x_milkv_duos_sd.dtb
-- 参考安装文档: https：//nuttx.apache.org/docs/latest/quickstart/install.html
+- Debian Linux 镜像 + U-Boot:https://github.com/Fishwaldo/sophgo-sg200x-debian/releases
+- 工具链:xPack https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases
+- dtb 文件：https://github.com/lupyuen2/wip-nuttx/releases/download/sg2000-1/cv181x_milkv_duos_sd.dtb
+- 参考安装文档: https://nuttx.apache.org/docs/latest/quickstart/install.html
 
 ### 硬件信息
 

--- a/Duo_S/NuttX/README_zh.md
+++ b/Duo_S/NuttX/README_zh.md
@@ -1,29 +1,27 @@
-# NuttX on Milk-V Duo S
+# NuttX on Milk-V Duo S 测试报告
 
 ## 测试环境
 
 ### 操作系统信息
 
-- Debian Linux 镜像 + U-Boot：https://github.com/Fishwaldo/sophgo-sg200x-debian/releases
-- 工具链：xPack https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases
-- dtb 文件：https://github.com/lupyuen2/wip-nuttx/releases/download/sg2000-1/cv181x_milkv_duos_sd.dtb
-- 参考安装文档：https://nuttx.apache.org/docs/latest/quickstart/install.html
+- Debian Linux Image + U-Boot: https://github.com/Fishwaldo/sophgo-sg200x-debian/releases
+- Toolchain: xPack https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases
+- dtb file: https://github.com/lupyuen2/wip-nuttx/releases/download/sg2000-1/cv181x_milkv_duos_sd.dtb
+- Reference Installation Document: https://nuttx.apache.org/docs/latest/quickstart/install.html
 
 ### 硬件信息
 
 - Milk-V Duo S (512M, SG2000)
-- USB 电源适配器一个
 - USB-A to C 或 USB C to C 线缆一条，用于给开发板供电
-- microSD 卡一张
-- USB 读卡器一个
-- USB to UART 调试器一个（如：CP2102, FT2232 等，注意不可使用 CH340/341 系列，会出现乱码）
-- 杜邦线三根
-- 以太网接入，用于 TFTP Boot
+- microSD 卡一张，用于启动
+- USB 读卡器一个，用于为microSD烧录
+- USB to UART 调试器一个（如：CP2102, FT2232 等，使用 CH340/341 系列开始会出现乱码，属于预期现象）
+- 杜邦线三根，用于uart接口
+- 网线一根，用于以太网接入（TFTP Boot 无法使用USB网络）
 
 ## 安装步骤
 
 ### 构建依赖安装
-
 
 Debian based:
 ```bash
@@ -77,11 +75,11 @@ git clone https://github.com/apache/nuttx-apps apps
 
 Nuttx 需要使用 xPack 工具链进行编译，首先获取工具链，从 Github 下载，自行改变版本以匹配你的系统：
 ```bash
-wget https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v11.5.0-1/xpack-riscv-none-elf-gcc-13.3.0-1-linux-x64.tar.gz
-tar -xvzf xpack-riscv-none-elf-gcc-13.3.0-1-linux-x64.tar.gz
+wget https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v14.2.0-2/xpack-riscv-none-elf-gcc-14.2.0-2-linux-x64.tar.gz
+tar -xvzf xpack-riscv-none-elf-gcc-14.2.0-2-linux-x64.tar.gz
 ```
 
-将其添加到你的 PATH 中：
+/*建议将tar解压到/opt*/并将其添加到你的 PATH 中：
 ```bash
 export PATH=/path/to/toolchain/you/untar:$PATH
 ```
@@ -92,7 +90,9 @@ cd nuttx
 tools/configure.sh milkv_duos:nsh
 make -j$(nproc)
 ```
-
+构建过程中如果遇到文件丢失，可以通过menuconfig配置选项
+- 在(Top) → Library Routines → Select math library 选择是否使用数学库，及其路径
+- 在(Top) → Library Routines → Builtin libclang_rt.profile选择是否启用llvm
 
 接下来构建文件系统：
 ```bash
@@ -139,7 +139,7 @@ cp Image-sg2000 /path/to/tftp/folder
 cp cv181x_milkv_duos_sd.dtb /path/to/tftp/folder
 ```
 
-接上 UART 调试线，给开发板上电，在提示 `Hit any key to stop autoboot` 时按任意键打断 U-Boot，并手动配置 U-Boot 以从 TFTP 启动 NuttX：
+接上 UART 调试线，给开发板上电，同时需要为开发板提供网络，在提示 `Hit any key to stop autoboot` 时按任意键打断 U-Boot，并手动配置 U-Boot 以从 TFTP 启动 NuttX：
 
 若是 dhcp 方式获取 ip，需要先运行`dhcp`而后打断。
 
@@ -195,11 +195,8 @@ nsh>
 
 屏幕录像：
 
-Part 1:
-[![asciicast](https://asciinema.org/a/8wvErVrySR04Ri18rPJ99qai9.svg)](https://asciinema.org/a/8wvErVrySR04Ri18rPJ99qai9)
+[!bilibili](https://www.bilibili.com/video/BV1RMUeYjELe/?spm_id_from=333.999.0.0)
 
-Part 2:
-[![asciicast](https://asciinema.org/a/loBvsK69TBtZmicjdzqHX2B9z.svg)](https://asciinema.org/a/loBvsK69TBtZmicjdzqHX2B9z)
 
 ## 测试判定标准
 
@@ -210,3 +207,5 @@ Part 2:
 ## 测试结论
 
 测试通过。
+
+

--- a/Duo_S/NuttX/README_zh.md
+++ b/Duo_S/NuttX/README_zh.md
@@ -4,10 +4,10 @@
 
 ### 操作系统信息
 
-- Debian Linux Image + U-Boot: https://github.com/Fishwaldo/sophgo-sg200x-debian/releases
-- Toolchain: xPack https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases
-- dtb file: https://github.com/lupyuen2/wip-nuttx/releases/download/sg2000-1/cv181x_milkv_duos_sd.dtb
-- Reference Installation Document: https://nuttx.apache.org/docs/latest/quickstart/install.html
+- Debian Linux 镜像 + U-Boot:https：//github.com/Fishwaldo/sophgo-sg200x-debian/releases
+- 工具链:xPack https：//github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases
+- dtb 文件：https：//github.com/lupyuen2/wip-nuttx/releases/download/sg2000-1/cv181x_milkv_duos_sd.dtb
+- 参考安装文档: https：//nuttx.apache.org/docs/latest/quickstart/install.html
 
 ### 硬件信息
 

--- a/Duo_S/NuttX/README_zh.md
+++ b/Duo_S/NuttX/README_zh.md
@@ -195,7 +195,7 @@ nsh>
 
 屏幕录像：
 
-[!asciinema](https://asciinema.org/a/Eai0QwU5y9USbr3FsYq7L1Mxf)(https://asciinema.org/a/Eai0QwU5y9USbr3FsYq7L1Mxf)
+[![asciinema](https://asciinema.org/a/Eai0QwU5y9USbr3FsYq7L1Mxf)](https://asciinema.org/a/Eai0QwU5y9USbr3FsYq7L1Mxf)
 
 
 ## 测试判定标准

--- a/Duo_S/NuttX/README_zh.md
+++ b/Duo_S/NuttX/README_zh.md
@@ -195,7 +195,7 @@ nsh>
 
 屏幕录像：
 
-[!bilibili](https://www.bilibili.com/video/BV1RMUeYjELe/?spm_id_from=333.999.0.0)
+[!asciinema](https://asciinema.org/a/Eai0QwU5y9USbr3FsYq7L1Mxf)(https://asciinema.org/a/Eai0QwU5y9USbr3FsYq7L1Mxf)
 
 
 ## 测试判定标准

--- a/Duo_S/NuttX/README_zh.md
+++ b/Duo_S/NuttX/README_zh.md
@@ -15,7 +15,7 @@
 - USB-A to C 或 USB C to C 线缆一条，用于给开发板供电
 - microSD 卡一张，用于启动
 - USB 读卡器一个，用于为microSD烧录
-- USB to UART 调试器一个（如：CP2102, FT2232 等，使用 CH340/341 系列开始会出现乱码，属于预期现象）
+- USB to UART 调试器一个（如：CP2102, FT2232 等，注意不可使用 CH340/341 系列，会出现乱码）
 - 杜邦线三根，用于uart接口
 - 网线一根，用于以太网接入（TFTP Boot 无法使用USB网络）
 
@@ -79,7 +79,7 @@ wget https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/downlo
 tar -xvzf xpack-riscv-none-elf-gcc-14.2.0-2-linux-x64.tar.gz
 ```
 
-/*建议将tar解压到/opt*/并将其添加到你的 PATH 中：
+建议将tar解压到/opt 并将其添加到你的 PATH 中：
 ```bash
 export PATH=/path/to/toolchain/you/untar:$PATH
 ```
@@ -90,9 +90,9 @@ cd nuttx
 tools/configure.sh milkv_duos:nsh
 make -j$(nproc)
 ```
-构建过程中如果遇到文件丢失，可以通过menuconfig配置选项
-- 在(Top) → Library Routines → Select math library 选择是否使用数学库，及其路径
-- 在(Top) → Library Routines → Builtin libclang_rt.profile选择是否启用llvm
+构建过程中如果遇到文件丢失，可以通过 menuconfig 配置选项
+- 在 (Top) → Library Routines → Select math library 选择是否使用数学库，及其路径
+- 在 (Top) → Library Routines → Builtin libclang_rt.profile 选择是否启用llvm
 
 接下来构建文件系统：
 ```bash

--- a/Mars/Deepin/README.md
+++ b/Mars/Deepin/README.md
@@ -78,4 +78,4 @@ Failed: The actual result does not match the expected result.
 
 ## Test Conclusion
 
-CFT
+Test successful.

--- a/Mars/Deepin/README.md
+++ b/Mars/Deepin/README.md
@@ -3,8 +3,8 @@ sys: deepin
 sys_ver: null
 sys_var: null
 
-status: cft
-last_update: 2024-06-21
+status: basic
+last_update: 2024-11-24
 ---
 
 # Deepin Milk-V Mars Test Report
@@ -51,16 +51,24 @@ The system should boot up normally and allow login via the serial port.
 
 ## Actual Results
 
-CFT
+The system starts normally and the output is successfully viewed through the serial port.
 
 ### Boot Log
 
 ```log
-
+root@deepin-riscv64-jh7110:/etc# cat /etc/os-release                            
+PRETTY_NAME="Deepin 23"                                                         
+NAME="Deepin"                                                                   
+VERSION_ID="23"                                                                 
+VERSION="23"                                                                    
+ID=deepin                                                                       
+HOME_URL="https://www.deepin.org/"                                              
+BUG_REPORT_URL="https://bbs.deepin.org"                                         
+VERSION_CODENAME=beige   
 ```
 
 Screen recording (from flashing the image to system login):
-
+[![asciinema](https://asciinema.org/a/EIM84vEQbB0JNug7ufjqykMOa)](https://asciinema.org/a/EIM84vEQbB0JNug7ufjqykMOa)
 
 ## Test Criteria
 

--- a/Mars/Deepin/README_zh.md
+++ b/Mars/Deepin/README_zh.md
@@ -44,16 +44,24 @@ sudo dd if=deepin-milkv-mars-riscv64-stable-desktop-installer.img of=/dev/sda bs
 
 ## 实际结果
 
-CFT
+系统正常启动，成功通过串口查看输出。
 
 ### 启动信息
 
 ```log
-
+root@deepin-riscv64-jh7110:/etc# cat /etc/os-release                            
+PRETTY_NAME="Deepin 23"                                                         
+NAME="Deepin"                                                                
+VERSION_ID="23"                                                                 
+VERSION="23"                                                                    
+ID=deepin                                                                       
+HOME_URL="https://www.deepin.org/"                                              
+BUG_REPORT_URL="https://bbs.deepin.org"                                         
+VERSION_CODENAME=beige   
 ```
 
 屏幕录像（从刷写镜像到登录系统）：
-
+[![asciinema](https://asciinema.org/a/47e6PqDygxjmg19rxBMepkECt)](https://asciinema.org/a/47e6PqDygxjmg19rxBMepkECt)
 ## 测试判定标准
 
 测试成功：实际结果与预期结果相符。

--- a/Mars/Ubuntu/README.md
+++ b/Mars/Ubuntu/README.md
@@ -68,6 +68,14 @@ The system starts normally and the output is successfully viewed through the ser
 
 Screen recording:
 [![asciicast](https://asciinema.org/a/S4BWlczAOVA6r3HmBrdtjP7Ul)](https://asciinema.org/a/S4BWlczAOVA6r3HmBrdtjP7Ul)
+
+```log
+Welcome to Ubuntu 24.04 LTS (GNU/Linux 6.8.0-31-generic riscv64)
+
+ * Documentation:  https://help.ubuntu.com
+ * Management:     https://landscape.canonical.com
+ * Support:        https://ubuntu.com/pro
+
  System information disabled due to load higher than 1.0
 
 Expanded Security Maintenance for Applications is not enabled.
@@ -105,7 +113,7 @@ BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
 PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
 UBUNTU_CODENAME=noble
 LOGO=ubuntu-logo
-ubuntu@ubuntu:~$ uname -a
+ubuntu@ubuntu:~$ uname -aMars/Ubuntu/README_zh.md Mars/Ubuntu/README.md
 Linux ubuntu 6.8.0-31-generic #31.1-Ubuntu SMP PREEMPT_DYNAMIC Sun Apr 21 01:12:53 UTC 2024 riscv64 riscv64 riscv64 GNU/Lix
 ubuntu@ubuntu:~$ 
  
@@ -121,4 +129,4 @@ Failed: The actual result does not match the expected result.
 ## Test Conclusion
 
 Test successful.
-</details>
+

--- a/Mars/Ubuntu/README.md
+++ b/Mars/Ubuntu/README.md
@@ -4,7 +4,7 @@ sys_ver: 24.10
 sys_var: null
 
 status: CFT
-last_update: 2024-10-25
+last_update: 2024-11-24
 ---
 
 # Ubuntu 24.10 on Milk-V Mars Test Report
@@ -68,7 +68,7 @@ The system booted successfully, and the output was successfully viewed via the s
 ### Boot Information
 
 Screen recording:
-[![asciicast](https://asciMars/Ubuntu/README_zh.md Mars/Ubuntu/README.md
+[![asciicast](https://asciinema.org/a/S4BWlczAOVA6r3HmBrdtjP7Ul)(https://asciinema.org/a/S4BWlczAOVA6r3HmBrdtjP7Ul)
  System information disabled due to load higher than 1.0
 
 Expanded Security Maintenance for Applications is not enabled.

--- a/Mars/Ubuntu/README.md
+++ b/Mars/Ubuntu/README.md
@@ -3,7 +3,7 @@ sys: ubuntu
 sys_ver: 24.10
 sys_var: null
 
-status: CFT
+status: basic
 last_update: 2024-11-24
 ---
 
@@ -61,14 +61,13 @@ Default password: `ubuntu`
 The system should boot normally, allowing login via the onboard serial port, and should enter the installation wizard.
 
 ## Actual Results
-<details>
-<summary>result is outdated(24.04)</summary>
-The system booted successfully, and the output was successfully viewed via the serial port.
+
+The system starts normally and the output is successfully viewed through the serial port.
 
 ### Boot Information
 
 Screen recording:
-[![asciicast](https://asciinema.org/a/S4BWlczAOVA6r3HmBrdtjP7Ul)(https://asciinema.org/a/S4BWlczAOVA6r3HmBrdtjP7Ul)
+[![asciicast](https://asciinema.org/a/S4BWlczAOVA6r3HmBrdtjP7Ul)](https://asciinema.org/a/S4BWlczAOVA6r3HmBrdtjP7Ul)
  System information disabled due to load higher than 1.0
 
 Expanded Security Maintenance for Applications is not enabled.

--- a/Mars/Ubuntu/README_zh.md
+++ b/Mars/Ubuntu/README_zh.md
@@ -52,8 +52,7 @@ sf update $kernel_addr_r 0x100000 $filesize
 系统正常启动，能够通过板载串口登录。能进入安装向导。
 
 ## 实际结果
-<details>
-<summary>结果已过时（24.04）</summary>
+
 系统正常启动，成功通过串口查看输出。
 
 ### 启动信息

--- a/Mars/Ubuntu/README_zh.md
+++ b/Mars/Ubuntu/README_zh.md
@@ -59,7 +59,7 @@ sf update $kernel_addr_r 0x100000 $filesize
 ### 启动信息
 
 屏幕录像：
-[![asciicast](https://asciinema.org/a/a3DgDMfhYPQgWhUjTTScbJ04n.svg)](https://asciinema.org/a/a3DgDMfhYPQgWhUjTTScbJ04n)
+[![asciicast](https://asciinema.org/a/S4BWlczAOVA6r3HmBrdtjP7Ul)](https://asciinema.org/a/S4BWlczAOVA6r3HmBrdtjP7Ul)
 
 ```log
 Welcome to Ubuntu 24.04 LTS (GNU/Linux 6.8.0-31-generic riscv64)

--- a/Mars/Ubuntu/README_zh.md
+++ b/Mars/Ubuntu/README_zh.md
@@ -6,7 +6,7 @@
 
 - Ubuntu 24.10
   - 下载链接：https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64+milkvmars.img.xz
-  - 参考安装文档：https://milkv.io/zh/docs/mars/getting-started/boot
+  - 参考安装文档：https://milkv.iso/zh/docs/mars/getting-started/boot
 
 ### 硬件开发板信息
 

--- a/Mars/Ubuntu/README_zh.md
+++ b/Mars/Ubuntu/README_zh.md
@@ -120,4 +120,4 @@ ubuntu@ubuntu:~$
 ## 测试结论
 
 成功
-</details>
+


### PR DESCRIPTION
Include following section:
DuoS/Buildroot to 1.1.3
DuoS/Fedora
DuoS/Nuttx
Mars/Deepin
Mars/Ubuntu24.10