### PR TITLE
BeagleV-Ahead: add RevyOS and openSUSE

### DIFF
--- a/BeagleV-Ahead/RevyOS/README.md
+++ b/BeagleV-Ahead/RevyOS/README.md
@@ -50,8 +50,8 @@ sudo fastboot reboot
 
 Logging into the system via serial port.
 
-Default username: `root`
-Default password: No password
+Default username: `debian`
+Default password: `debian`
 
 ## Expected Results
 

--- a/BeagleV-Ahead/RevyOS/README.md
+++ b/BeagleV-Ahead/RevyOS/README.md
@@ -31,7 +31,7 @@ Install fastboot:
 sudo apt-get install android-sdk-platform-tools
 ```
 
-Unpack the installation package. Run the automatic flashing script:
+Unpack the installation package. Run the following commands:
 
 ```bash
 zstd -d boot-ahead-20231210_134926.ext4.zst -o boot.ext4

--- a/BeagleV-Ahead/RevyOS/README.md
+++ b/BeagleV-Ahead/RevyOS/README.md
@@ -1,0 +1,80 @@
+---
+sys: RevyOS
+sys_ver: 20231210
+sys_var: null
+
+status: CFT
+last_update: 2024-12-12
+---
+
+# RevyOS BeagleV-Ahead Test Report
+
+## Test Environment
+
+### System Information
+
+- Download link: https://mirror.iscas.ac.cn/revyos/extra/images/beagle/20231210/
+- Reference Installation Document: https://docs.beagleboard.org/latest/boards/beaglev/ahead/02-quick-start.html
+
+### Hardware Information
+
+- BeagleV-Ahead
+- USB-C Power Adapter / DC power supply
+- USB-UART debugger
+
+## Installation Steps
+
+### Flashing Image 
+
+Install fastboot:
+```bash
+sudo apt-get install android-sdk-platform-tools
+```
+
+Unpack the installation package. Run the automatic flashing script:
+
+```bash
+zstd -d boot-ahead-20231210_134926.ext4.zst -o boot.ext4
+zstd -d root-ahead-20231210_134926.ext4.zst -o root.ext4
+
+sudo fastboot flash ram ./u-boot-with-spl.bin
+sudo fastboot reboot
+sudo fastboot oem format
+sudo fastboot flash uboot ./u-boot-with-spl.bin
+sudo fastboot flash boot ./boot.ext4
+sudo fastboot flash root ./root.ext4
+sudo fastboot reboot
+```
+
+### Logging into the System
+
+Logging into the system via serial port.
+
+Default username: `root`
+Default password: No password
+
+## Expected Results
+
+The system boots up successfully and can be logged into through the onboard serial port.
+
+## Actual Results
+
+CFT
+
+### Boot Log
+
+Screen recording (from flashing the image to startup):
+
+```log
+
+```
+
+## Test Criteria
+
+Successful: The actual result matches the expected result.
+
+Failed: The actual result does not match the expected result.
+
+## Test Conclusion
+
+CFT

--- a/BeagleV-Ahead/RevyOS/README_zh.md
+++ b/BeagleV-Ahead/RevyOS/README_zh.md
@@ -1,0 +1,73 @@
+# RevyOS BeagleV-Ahead 测试报告
+
+## 测试环境
+
+### 操作系统信息
+
+- 下载链接：https://mirror.iscas.ac.cn/revyos/extra/images/beagle/20231210/
+- 参考安装文档：https://docs.beagleboard.org/latest/boards/beaglev/ahead/02-quick-start.html
+
+### 硬件信息
+
+- BeagleV-Ahead
+- USB-C 电源适配器 / DC 电源一个
+- USB-UART 调试器一个
+
+## 安装步骤
+
+### 刷写镜像
+
+安装 fastboot：
+```bash
+sudo apt-get install android-sdk-platform-tools
+```
+
+解压安装套件。运行自动刷写脚本：
+
+```bash
+zstd -d boot-ahead-20231210_134926.ext4.zst -o boot.ext4
+zstd -d root-ahead-20231210_134926.ext4.zst -o root.ext4
+
+sudo fastboot flash ram ./u-boot-with-spl.bin
+sudo fastboot reboot
+sudo fastboot oem format
+sudo fastboot flash uboot ./u-boot-with-spl.bin
+sudo fastboot flash boot ./boot.ext4
+sudo fastboot flash root ./root.ext4
+sudo fastboot reboot
+```
+
+### 登录系统
+
+通过串口登录系统。
+
+默认用户名： `root`
+默认密码：无密码
+
+## 预期结果
+
+系统正常启动，能够通过板载串口登录。
+
+## 实际结果
+
+CFT
+
+### 启动信息
+
+屏幕录像（从刷写镜像到登录系统）：
+
+
+```log
+
+```
+
+
+## 测试判定标准
+
+测试成功：实际结果与预期结果相符。
+
+测试失败：实际结果与预期结果不符。
+
+## 测试结论
+
+CFT

--- a/BeagleV-Ahead/RevyOS/README_zh.md
+++ b/BeagleV-Ahead/RevyOS/README_zh.md
@@ -22,7 +22,7 @@
 sudo apt-get install android-sdk-platform-tools
 ```
 
-解压安装套件。运行自动刷写脚本：
+解压安装套件。运行如下指令：
 
 ```bash
 zstd -d boot-ahead-20231210_134926.ext4.zst -o boot.ext4

--- a/BeagleV-Ahead/RevyOS/README_zh.md
+++ b/BeagleV-Ahead/RevyOS/README_zh.md
@@ -41,8 +41,8 @@ sudo fastboot reboot
 
 通过串口登录系统。
 
-默认用户名： `root`
-默认密码：无密码
+默认用户名： `debian`
+默认密码： `debian`
 
 ## 预期结果
 

--- a/BeagleV-Ahead/others.yml
+++ b/BeagleV-Ahead/others.yml
@@ -1,3 +1,7 @@
+- sys: openSUSE
+  sys_ver: null
+  sys_var: null
+  status: cft
 - sys: android
   sys_ver: null
   sys_var: null


### PR DESCRIPTION
Can't figure out how to install [openSUSE](https://download.opensuse.org/repositories/devel:/RISCV:/Factory:/Contrib:/BeagleV-Ahead/images/).