### PR TITLE
Add TTGO T-Display-GD32 board & Add μC/OS-II

### DIFF
--- a/Longan_Nano/README.md
+++ b/Longan_Nano/README.md
@@ -10,7 +10,7 @@ cpu_core: Nuclei Bumblebee
 
 ### Operating System Information
 
-- FreeRTOS/RT-Thread/ThreadX
+- FreeRTOS/RT-Thread/ThreadX/μCOS-II
     - Source Code: https://github.com/Nuclei-Software/nuclei-sdk
     - Reference Installation Document: https://doc.nucleisys.com/nuclei_sdk/quickstart.html#build-run-and-debug-sample-application
         - https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_longan_nano.html
@@ -30,9 +30,10 @@ cpu_core: Nuclei Bumblebee
 | RT-Thread         | N/A          | [Success][RT-Thread]       |
 | Zephyr            | N/A          | [Success][Zephyr]          |
 | ThreadX           | N/A          | [Success][ThreadX]         |
+| μC/OS-II          | N/A          | [Success][uCOSII]          |
 
 [FreeRTOS]: ./FreeRTOS/README.md
 [RT-Thread]: ./RT-Thread/README.md
 [ThreadX]: ./ThreadX/README.md
 [Zephyr]: ./Zephyr/README.md
-
+[uCOSII]: ./uCOSII/README.md

--- a/Longan_Nano/README_zh.md
+++ b/Longan_Nano/README_zh.md
@@ -4,7 +4,7 @@
 
 ### 操作系统信息
 
-- FreeRTOS/RT-Thread/ThreadX
+- FreeRTOS/RT-Thread/ThreadX/μCOS-II
     - 源码链接：https://github.com/Nuclei-Software/nuclei-sdk
     - 参考文档：https://doc.nucleisys.com/nuclei_sdk/quickstart.html#build-run-and-debug-sample-application
         - https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_longan_nano.html
@@ -24,8 +24,10 @@
 | RT-Thread | N/A      | [成功][RT-Thread]    |
 | ThreadX   | N/A      | [成功][RT-Thread]    |
 | Zephyr    | N/A      | [成功][Zephyr]       |
+| μC/OS-II  | N/A      | [成功][uCOSII]       |
 
 [FreeRTOS]: ./FreeRTOS/README_zh.md
 [RT-Thread]: ./RT-Thread/README_zh.md
 [ThreadX]: ./ThreadX/README_zh.md
 [Zephyr]: ./Zephyr/README_zh.md
+[uCOSII]: ./uCOSII/README_zh.md

--- a/Longan_Nano/uCOSII/README.md
+++ b/Longan_Nano/uCOSII/README.md
@@ -1,0 +1,201 @@
+---
+sys: ucosii
+sys_ver: null
+sys_var: null
+
+status: basic
+last_update: 2025-02-24
+---
+
+# μC/OS-II TTGO T-Display-GD32 Test Report
+
+## Test Environment
+
+### Operating System Information
+
+- Source Code Link: https://github.com/Nuclei-Software/nuclei-sdk
+- Reference Installation Document: https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_t_display.html
+- Download Links:
+    - SDK: https://github.com/Nuclei-Software/nuclei-sdk
+    - Toolchain: https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+    - OpenOCD: https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+
+### Hardware Information
+
+- TTGO T-Display-GD32
+- A USB to UART Debugger
+- **JTAG Debugger**
+- A Type-C Cable
+
+## Installation Steps
+
+### Configure Environment
+
+Download and extract the toolchain and OpenOCD, then set the toolchain directory:
+```bash
+wget https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+tar -xjvf nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+wget https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+tar -xzvf nuclei-openocd-2024.02.28-linux-x64.tgz
+export NUCLEI_TOOL_ROOT=$(pwd)
+```
+
+Download the SDK:
+```bash
+git clone https://github.com/Nuclei-Software/nuclei-sdk.git
+cd nuclei-sdk
+echo "NUCLEI_TOOL_ROOT=$(echo $NUCLEI_TOOL_ROOT)" > setup_config.sh
+
+source setup.sh
+```
+
+### Compile Code
+
+Compile μC/OS-II:
+```bash
+cd application/ucosii/demo/
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display clean
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display all
+```
+
+### Flash Image
+
+Connect to the development board via your JTAG debugger. Note that the board should be powered on while flashing.
+
+Make sure your debugger and OpenOCD binary is supported by the build system.
+For the former, consider editing relevant settings in `../../../SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg` to match your JTAG debugger.
+e.g. with Sipeed SLogic Combo 8 debugger at DAP-Link mode:
+```diff
+diff --git a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+index 019218da..66895b18 100644
+--- a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
++++ b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+@@ -2,8 +2,8 @@ adapter speed     5000
+ reset_config    srst_only
+ adapter srst pulse_width 100
+ 
+-adapter driver ftdi
+-ftdi vid_pid 0x0403 0x6010
++adapter driver cmsis-dap
++cmsis-dap vid_pid 0xd6e7 0x3507
+ 
+ ## bindto 0.0.0.0 can be used to cover all available interfaces.
+ ## Uncomment bindto line to enable remote machine debug
+@@ -25,14 +25,14 @@ if { [ info exists JTAGSN ] } {
+     adapter serial $JTAGSN
+ }
+ 
+-ftdi layout_init 0x0008 0x001b
+-ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
++#ftdi layout_init 0x0008 0x001b
++#ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
+ # These signals are used for cJTAG escape sequence on initialization only
+-ftdi layout_signal TCK -data 0x0001
+-ftdi layout_signal TDI -data 0x0002
+-ftdi layout_signal TDO -input 0x0004
+-ftdi layout_signal TMS -data 0x0008
+-ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
++#ftdi layout_signal TCK -data 0x0001
++#ftdi layout_signal TDI -data 0x0002
++#ftdi layout_signal TDO -input 0x0004
++#ftdi layout_signal TMS -data 0x0008
++#ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
+ transport select jtag
+ 
+ set _CHIPNAME riscv
+```
+
+Also adding an udev rule if necessary (refer to https://github.com/arduino/OpenOCD/blob/master/contrib/60-openocd.rules)
+For the latter, make sure your OpenOCD version is up to date with support for your debugger; a known usable version is at https://github.com/xpack-dev-tools/openocd-xpack/releases/tag/v0.12.0-4
+
+When all set, flash the binary with:
+```bash
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
+```
+
+### Start System
+
+Connect to the development board via serial port.
+
+## Expected Results
+
+The system should boot normally and provide information via the onboard serial port.
+
+## Actual Results
+
+The system booted up normally, and information are viewable via the onboard serial port.
+
+### Boot Log
+
+```log
+Nuclei SDK Build Time: Feb 24 2025, 16:20:57
+Download Mode: FLASHXIP
+CPU Frequency 108000000 Hz
+Start ucosii...
+create start task success
+start all task...
+task3 is running... 1
+task2 is running... 1
+task1 is running... 1
+task3 is running... 2
+task2 is running... 2
+task1 is running... 2
+task3 is running... 3
+task2 is running... 3
+task3 is running... 4
+task2 is running... 4
+task1 is running... 3
+task3 is running... 5
+task2 is running... 5
+task3 is running... 6
+task2 is running... 6
+task1 is running... 4
+task3 is running... 7
+task2 is running... 7
+task3 is running... 8
+task2 is running... 8
+task1 is running... 5
+task3 is running... 9
+task2 is running... 9
+task3 is running... 10
+task2 is running... 10
+task1 is running... 6
+task3 is running... 11
+task2 is running... 11
+task3 is running... 12
+task2 is running... 12
+task1 is running... 7
+task3 is running... 13
+task2 is running... 13
+task3 is running... 14
+task2 is running... 14
+task1 is running... 8
+task3 is running... 15
+task2 is running... 15
+task3 is running... 16
+task2 is running... 16
+task1 is running... 9
+task3 is running... 17
+task2 is running... 17
+task3 is running... 18
+task2 is running... 18
+task1 is running... 10
+task3 is running... 19
+task2 is running... 19
+task3 is running... 20
+task2 is running... 20
+
+(truncated)
+```
+
+## Test Criteria
+
+Successful: The actual result matches the expected result.
+
+Failed: The actual result does not match the expected result.
+
+## Test Conclusion
+
+Test successful.

--- a/Longan_Nano/uCOSII/README_zh.md
+++ b/Longan_Nano/uCOSII/README_zh.md
@@ -1,0 +1,191 @@
+# μC/OS-II TTGO T-Display-GD32 测试报告
+
+## 测试环境
+
+### 操作系统信息
+
+- 源码链接：https://github.com/Nuclei-Software/nuclei-sdk
+- 参考文档：https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_t_display.html
+- 下载链接：
+    - SDK：https://github.com/Nuclei-Software/nuclei-sdk
+    - toolchain：https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+    - openocd：https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+
+### 硬件信息
+
+- TTGO T-Display-GD32
+- USB to UART 调试器一个
+- **JTAG 调试器**
+- type-c 线一根
+
+## 安装步骤
+
+### 配置环境
+
+下载工具链和 OpenOCD 并解压，设置工具链目录：
+```bash
+wget https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+tar -xjvf nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+wget https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+tar -xzvf nuclei-openocd-2024.02.28-linux-x64.tgz
+export NUCLEI_TOOL_ROOT=$(pwd)
+```
+
+下载 SDK：
+```bash
+git clone https://github.com/Nuclei-Software/nuclei-sdk.git
+cd nuclei-sdk
+echo "NUCLEI_TOOL_ROOT=$(echo $NUCLEI_TOOL_ROOT)" > setup_config.sh
+source setup.sh
+```
+
+### 编译代码
+
+编译 μC/OS-II:
+```bash
+cd application/ucosii/demo/
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display clean
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display all
+```
+
+### 烧写镜像
+
+通过 JTAG 调试器连接开发板。注意刷写期间板子需上电。
+
+请确保所使用的调试器和 OpenOCD 版本和编译系统兼容。对于前者，可在 `../../../SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg` 参考所使用的调试器种类编辑相应的 OpenOCD 参数。
+例如，使用 Sipeed SLogic Combo 8 调试器 （DAP-Link 模式）时:
+```diff
+diff --git a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+index 019218da..66895b18 100644
+--- a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
++++ b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+@@ -2,8 +2,8 @@ adapter speed     5000
+ reset_config    srst_only
+ adapter srst pulse_width 100
+ 
+-adapter driver ftdi
+-ftdi vid_pid 0x0403 0x6010
++adapter driver cmsis-dap
++cmsis-dap vid_pid 0xd6e7 0x3507
+ 
+ ## bindto 0.0.0.0 can be used to cover all available interfaces.
+ ## Uncomment bindto line to enable remote machine debug
+@@ -25,14 +25,14 @@ if { [ info exists JTAGSN ] } {
+     adapter serial $JTAGSN
+ }
+ 
+-ftdi layout_init 0x0008 0x001b
+-ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
++#ftdi layout_init 0x0008 0x001b
++#ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
+ # These signals are used for cJTAG escape sequence on initialization only
+-ftdi layout_signal TCK -data 0x0001
+-ftdi layout_signal TDI -data 0x0002
+-ftdi layout_signal TDO -input 0x0004
+-ftdi layout_signal TMS -data 0x0008
+-ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
++#ftdi layout_signal TCK -data 0x0001
++#ftdi layout_signal TDI -data 0x0002
++#ftdi layout_signal TDO -input 0x0004
++#ftdi layout_signal TMS -data 0x0008
++#ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
+ transport select jtag
+ 
+ set _CHIPNAME riscv
+```
+如有必要可添加对应的 udev 规则 （参考 https://github.com/arduino/OpenOCD/blob/master/contrib/60-openocd.rules）。
+
+对于后者，工具链中提供的 OpenOCD 版本可能不兼容某些种类的调试器。一个已知可用的版本在 https://github.com/xpack-dev-tools/openocd-xpack/releases/tag/v0.12.0-4 。
+
+准备就绪后，使用如下命令烧写：
+
+```bash
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
+```
+
+### 启动系统
+
+通过串口连接开发板。
+
+## 预期结果
+
+系统正常启动，能够通过板载串口查看信息。
+
+## 实际结果
+
+系统正常启动，能够通过板载串口查看信息。
+
+### 启动信息
+
+```log
+Nuclei SDK Build Time: Feb 24 2025, 16:20:57
+Download Mode: FLASHXIP
+CPU Frequency 108000000 Hz
+Start ucosii...
+create start task success
+start all task...
+task3 is running... 1
+task2 is running... 1
+task1 is running... 1
+task3 is running... 2
+task2 is running... 2
+task1 is running... 2
+task3 is running... 3
+task2 is running... 3
+task3 is running... 4
+task2 is running... 4
+task1 is running... 3
+task3 is running... 5
+task2 is running... 5
+task3 is running... 6
+task2 is running... 6
+task1 is running... 4
+task3 is running... 7
+task2 is running... 7
+task3 is running... 8
+task2 is running... 8
+task1 is running... 5
+task3 is running... 9
+task2 is running... 9
+task3 is running... 10
+task2 is running... 10
+task1 is running... 6
+task3 is running... 11
+task2 is running... 11
+task3 is running... 12
+task2 is running... 12
+task1 is running... 7
+task3 is running... 13
+task2 is running... 13
+task3 is running... 14
+task2 is running... 14
+task1 is running... 8
+task3 is running... 15
+task2 is running... 15
+task3 is running... 16
+task2 is running... 16
+task1 is running... 9
+task3 is running... 17
+task2 is running... 17
+task3 is running... 18
+task2 is running... 18
+task1 is running... 10
+task3 is running... 19
+task2 is running... 19
+task3 is running... 20
+task2 is running... 20
+
+(truncated)
+```
+
+## 测试判定标准
+
+测试成功：实际结果与预期结果相符。
+
+测试失败：实际结果与预期结果不符。
+
+## 测试结论
+
+测试成功。

--- a/TTGO_T_Display/FreeRTOS/README.md
+++ b/TTGO_T_Display/FreeRTOS/README.md
@@ -115,6 +115,23 @@ When all set, flash the binary with:
 make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
 ```
 
+> Still unable to connect to the board? Try re-flashing its firmware via its DFU bootloader.
+> 
+> Download the firmware from here: https://github.com/Xinyuan-LilyGO/LilyGO-T-DisplayGD32/raw/refs/heads/master/firmware/GD32V_CBT6_20200116.bin
+> 
+> Press the BOOT button while plugging in the board to enter DFU mode. `lsusb` should show something like:
+> 
+> ```shell
+> Bus 001 Device 047: ID 28e9:0189 GDMicroelectronics GD32 DFU Bootloader (Longan Nano)
+> # "Longan Nano" is intended behavior
+> ```
+
+> Flash the firmware with `gd32-dfu-utils` (https://github.com/riscv-mcu/gd32-dfu-utils):
+> 
+> ```shell
+> sudo gd32-dfu-util -D GD32V_CBT6_20200116.bin
+> ```
+
 ### Start System
 
 Connect to the development board via serial port.

--- a/TTGO_T_Display/FreeRTOS/README.md
+++ b/TTGO_T_Display/FreeRTOS/README.md
@@ -1,0 +1,188 @@
+---
+sys: freertos
+sys_ver: null
+sys_var: null
+
+status: basic
+last_update: 2025-02-24
+---
+
+# FreeRTOS TTGO T-Display-GD32 Test Report
+
+## Test Environment
+
+### Operating System Information
+
+- Source Code Link: https://github.com/Nuclei-Software/nuclei-sdk
+- Reference Installation Document: https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_t_display.html
+- Download Links:
+    - SDK: https://github.com/Nuclei-Software/nuclei-sdk
+    - Toolchain: https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+    - OpenOCD: https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+
+### Hardware Information
+
+- TTGO T-Display-GD32
+- A USB to UART Debugger
+- **JTAG Debugger**
+- A Type-C Cable
+
+## Installation Steps
+
+### Configure Environment
+
+Download and extract the toolchain and OpenOCD, then set the toolchain directory:
+```bash
+wget https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+tar -xjvf nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+wget https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+tar -xzvf nuclei-openocd-2024.02.28-linux-x64.tgz
+export NUCLEI_TOOL_ROOT=$(pwd)
+```
+
+Download the SDK:
+```bash
+git clone https://github.com/Nuclei-Software/nuclei-sdk.git
+cd nuclei-sdk
+echo "NUCLEI_TOOL_ROOT=$(echo $NUCLEI_TOOL_ROOT)" > setup_config.sh
+
+source setup.sh
+```
+
+### Compile Code
+
+Compile FreeRTOS:
+```bash
+cd application/freertos/demo/
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display clean
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display all
+```
+
+### Flash Image
+
+Connect to the development board via your JTAG debugger. Note that the board should be powered on while flashing.
+
+Make sure your debugger and OpenOCD binary is supported by the build system.
+For the former, consider editing relevant settings in `../../../SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg` to match your JTAG debugger.
+e.g. with Sipeed SLogic Combo 8 debugger at DAP-Link mode:
+```diff
+diff --git a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+index 019218da..66895b18 100644
+--- a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
++++ b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+@@ -2,8 +2,8 @@ adapter speed     5000
+ reset_config    srst_only
+ adapter srst pulse_width 100
+ 
+-adapter driver ftdi
+-ftdi vid_pid 0x0403 0x6010
++adapter driver cmsis-dap
++cmsis-dap vid_pid 0xd6e7 0x3507
+ 
+ ## bindto 0.0.0.0 can be used to cover all available interfaces.
+ ## Uncomment bindto line to enable remote machine debug
+@@ -25,14 +25,14 @@ if { [ info exists JTAGSN ] } {
+     adapter serial $JTAGSN
+ }
+ 
+-ftdi layout_init 0x0008 0x001b
+-ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
++#ftdi layout_init 0x0008 0x001b
++#ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
+ # These signals are used for cJTAG escape sequence on initialization only
+-ftdi layout_signal TCK -data 0x0001
+-ftdi layout_signal TDI -data 0x0002
+-ftdi layout_signal TDO -input 0x0004
+-ftdi layout_signal TMS -data 0x0008
+-ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
++#ftdi layout_signal TCK -data 0x0001
++#ftdi layout_signal TDI -data 0x0002
++#ftdi layout_signal TDO -input 0x0004
++#ftdi layout_signal TMS -data 0x0008
++#ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
+ transport select jtag
+ 
+ set _CHIPNAME riscv
+```
+
+Also adding an udev rule if necessary (refer to https://github.com/arduino/OpenOCD/blob/master/contrib/60-openocd.rules)
+For the latter, make sure your OpenOCD version is up to date with support for your debugger; a known usable version is at https://github.com/xpack-dev-tools/openocd-xpack/releases/tag/v0.12.0-4
+
+When all set, flash the binary with:
+```bash
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
+```
+
+### Start System
+
+Connect to the development board via serial port.
+
+## Expected Results
+
+The system should boot normally and provide information via the onboard serial port.
+
+## Actual Results
+
+The system booted up normally, and information are viewable via the onboard serial port.
+
+### Boot Log
+
+```log
+Nuclei SDK Build Time: Feb 22 2025, 20:04:27
+Download Mode: FLASHXIP
+CPU Frequency 108000000 Hz
+Before StartScheduler
+Enter to task_1
+task1 is running 0.....
+Enter to task_2
+task2 is running 0.....
+task1 is running 1.....
+task2 is running 1.....
+task1 is running 2.....
+task2 is running 2.....
+task1 is running 3.....
+task2 is running 3.....
+task1 is running 4.....
+task2 is running 4.....
+timers Callback 0
+task1 is running 5.....
+task2 is running 5.....
+task1 is running 6.....
+task2 is running 6.....
+task1 is running 7.....
+task2 is running 7.....
+task1 is running 8.....
+task2 is running 8.....
+task1 is running 9.....
+task2 is running 9.....
+timers Callback 1
+task1 is running 10.....
+task2 is running 10.....
+task1 is running 11.....
+task2 is running 11.....
+task1 is running 12.....
+task2 is running 12.....
+task1 is running 13.....
+task2 is running 13.....
+task1 is running 14.....
+task2 is running 14.....
+timers Callback 2
+task1 is running 15.....
+task2 is running 15.....
+task1 is running 16.....
+task2 is running 16.....
+
+(truncated)
+```
+
+## Test Criteria
+
+Successful: The actual result matches the expected result.
+
+Failed: The actual result does not match the expected result.
+
+## Test Conclusion
+
+Test successful.

--- a/TTGO_T_Display/FreeRTOS/README_zh.md
+++ b/TTGO_T_Display/FreeRTOS/README_zh.md
@@ -1,0 +1,178 @@
+# FreeRTOS TTGO T-Display-GD32 测试报告
+
+## 测试环境
+
+### 操作系统信息
+
+- 源码链接：https://github.com/Nuclei-Software/nuclei-sdk
+- 参考文档：https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_t_display.html
+- 下载链接：
+    - SDK：https://github.com/Nuclei-Software/nuclei-sdk
+    - toolchain：https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+    - openocd：https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+
+### 硬件信息
+
+- TTGO T-Display-GD32
+- USB to UART 调试器一个
+- **JTAG 调试器**
+- type-c 线一根
+
+## 安装步骤
+
+### 配置环境
+
+下载工具链和 OpenOCD 并解压，设置工具链目录：
+```bash
+wget https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+tar -xjvf nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+wget https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+tar -xzvf nuclei-openocd-2024.02.28-linux-x64.tgz
+export NUCLEI_TOOL_ROOT=$(pwd)
+```
+
+下载 SDK：
+```bash
+git clone https://github.com/Nuclei-Software/nuclei-sdk.git
+cd nuclei-sdk
+echo "NUCLEI_TOOL_ROOT=$(echo $NUCLEI_TOOL_ROOT)" > setup_config.sh
+source setup.sh
+```
+
+### 编译代码
+
+编译 FreeRTOS:
+```bash
+cd application/freertos/demo/
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display clean
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display all
+```
+
+### 烧写镜像
+
+通过 JTAG 调试器连接开发板。注意刷写期间板子需上电。
+
+请确保所使用的调试器和 OpenOCD 版本和编译系统兼容。对于前者，可在 `../../../SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg` 参考所使用的调试器种类编辑相应的 OpenOCD 参数。
+例如，使用 Sipeed SLogic Combo 8 调试器 （DAP-Link 模式）时:
+```diff
+diff --git a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+index 019218da..66895b18 100644
+--- a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
++++ b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+@@ -2,8 +2,8 @@ adapter speed     5000
+ reset_config    srst_only
+ adapter srst pulse_width 100
+ 
+-adapter driver ftdi
+-ftdi vid_pid 0x0403 0x6010
++adapter driver cmsis-dap
++cmsis-dap vid_pid 0xd6e7 0x3507
+ 
+ ## bindto 0.0.0.0 can be used to cover all available interfaces.
+ ## Uncomment bindto line to enable remote machine debug
+@@ -25,14 +25,14 @@ if { [ info exists JTAGSN ] } {
+     adapter serial $JTAGSN
+ }
+ 
+-ftdi layout_init 0x0008 0x001b
+-ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
++#ftdi layout_init 0x0008 0x001b
++#ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
+ # These signals are used for cJTAG escape sequence on initialization only
+-ftdi layout_signal TCK -data 0x0001
+-ftdi layout_signal TDI -data 0x0002
+-ftdi layout_signal TDO -input 0x0004
+-ftdi layout_signal TMS -data 0x0008
+-ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
++#ftdi layout_signal TCK -data 0x0001
++#ftdi layout_signal TDI -data 0x0002
++#ftdi layout_signal TDO -input 0x0004
++#ftdi layout_signal TMS -data 0x0008
++#ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
+ transport select jtag
+ 
+ set _CHIPNAME riscv
+```
+如有必要可添加对应的 udev 规则 （参考 https://github.com/arduino/OpenOCD/blob/master/contrib/60-openocd.rules）。
+
+对于后者，工具链中提供的 OpenOCD 版本可能不兼容某些种类的调试器。一个已知可用的版本在 https://github.com/xpack-dev-tools/openocd-xpack/releases/tag/v0.12.0-4 。
+
+准备就绪后，使用如下命令烧写：
+
+```bash
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
+```
+
+### 启动系统
+
+通过串口连接开发板。
+
+## 预期结果
+
+系统正常启动，能够通过板载串口查看信息。
+
+## 实际结果
+
+系统正常启动，能够通过板载串口查看信息。
+
+### 启动信息
+
+```log
+Nuclei SDK Build Time: Feb 22 2025, 20:04:27
+Download Mode: FLASHXIP
+CPU Frequency 108000000 Hz
+Before StartScheduler
+Enter to task_1
+task1 is running 0.....
+Enter to task_2
+task2 is running 0.....
+task1 is running 1.....
+task2 is running 1.....
+task1 is running 2.....
+task2 is running 2.....
+task1 is running 3.....
+task2 is running 3.....
+task1 is running 4.....
+task2 is running 4.....
+timers Callback 0
+task1 is running 5.....
+task2 is running 5.....
+task1 is running 6.....
+task2 is running 6.....
+task1 is running 7.....
+task2 is running 7.....
+task1 is running 8.....
+task2 is running 8.....
+task1 is running 9.....
+task2 is running 9.....
+timers Callback 1
+task1 is running 10.....
+task2 is running 10.....
+task1 is running 11.....
+task2 is running 11.....
+task1 is running 12.....
+task2 is running 12.....
+task1 is running 13.....
+task2 is running 13.....
+task1 is running 14.....
+task2 is running 14.....
+timers Callback 2
+task1 is running 15.....
+task2 is running 15.....
+task1 is running 16.....
+task2 is running 16.....
+
+(truncated)
+```
+
+## 测试判定标准
+
+测试成功：实际结果与预期结果相符。
+
+测试失败：实际结果与预期结果不符。
+
+## 测试结论
+
+测试成功。

--- a/TTGO_T_Display/FreeRTOS/README_zh.md
+++ b/TTGO_T_Display/FreeRTOS/README_zh.md
@@ -105,6 +105,23 @@ index 019218da..66895b18 100644
 make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
 ```
 
+> 如果还是无法连接到开发板，可尝试重新烧写其固件进DFU。
+> 
+> 从这里下载固件：https://github.com/Xinyuan-LilyGO/LilyGO-T-DisplayGD32/raw/refs/heads/master/firmware/GD32V_CBT6_20200116.bin
+> 
+> 按住开发板上的 BOOT 按钮的同时上电，进入 DFU 模式，此时 `lsusb` 应有例如：
+> 
+> ```shell
+> Bus 001 Device 047: ID 28e9:0189 GDMicroelectronics GD32 DFU Bootloader (Longan Nano)
+> # 显示 Longan Nano 为正常现象
+> ```
+
+> 使用 `gd32-dfu-utils` (https://github.com/riscv-mcu/gd32-dfu-utils) 烧写固件：
+> 
+> ```shell
+> sudo gd32-dfu-util -D GD32V_CBT6_20200116.bin
+> ```
+
 ### 启动系统
 
 通过串口连接开发板。

--- a/TTGO_T_Display/README.md
+++ b/TTGO_T_Display/README.md
@@ -1,0 +1,35 @@
+---
+product: TTGO T-Display-GD32
+cpu: GD32VF103
+cpu_core: Nuclei Bumblebee
+---
+
+# TTGO T-Display-GD32
+
+## Test Environment
+
+### Operating System Information
+
+- FreeRTOS/RT-Thread/ThreadX/μCOS-II
+    - Source Code: https://github.com/Nuclei-Software/nuclei-sdk
+    - Reference Installation Document: https://doc.nucleisys.com/nuclei_sdk/quickstart.html#build-run-and-debug-sample-application
+        - https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_t_display.html
+
+### Hardware Information
+
+- TTGO T-Display-GD32 (GD32VF103CBT6)
+
+## Test Results
+
+| Software Category | Package Name | Test Results (Test Report) |
+| ----------------- | ------------ | -------------------------- |
+| FreeRTOS          | N/A          | [Success][FreeRTOS]        |
+| RT-Thread         | N/A          | [Success][RT-Thread]       |
+| uCOSII            | N/A          | [Success][uCOSII]          |
+| ThreadX           | N/A          | [Success][ThreadX]         |
+
+[FreeRTOS]: ./FreeRTOS/README.md
+[RT-Thread]: ./RT-Thread/README.md
+[ThreadX]: ./ThreadX/README.md
+[uCOSII]: ./uCOSII/README.md
+

--- a/TTGO_T_Display/README_zh.md
+++ b/TTGO_T_Display/README_zh.md
@@ -1,0 +1,28 @@
+# TTGO T-Display-GD32
+
+## 测试环境
+
+### 操作系统信息
+
+- FreeRTOS/RT-Thread/ThreadX/μCOS-II
+    - 源码链接：https://github.com/Nuclei-Software/nuclei-sdk
+    - 参考文档：https://doc.nucleisys.com/nuclei_sdk/quickstart.html#build-run-and-debug-sample-application
+        - https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_t_display.html
+
+### 硬件开发板信息
+
+- TTGO T-Display-GD32 (GD32VF103CBT6)
+
+## 测试结果
+
+| 软件分类  | 软件包名 | 测试结果（测试报告） |
+| --------- | -------- | -------------------- |
+| FreeRTOS  | N/A      | [成功][FreeRTOS]     |
+| RT-Thread | N/A      | [成功][RT-Thread]    |
+| ThreadX   | N/A      | [成功][RT-Thread]    |
+| μC/OS-II  | N/A      | [成功][uCOSII]       |
+
+[FreeRTOS]: ./FreeRTOS/README_zh.md
+[RT-Thread]: ./RT-Thread/README_zh.md 
+[ThreadX]: ./ThreadX/README_zh.md
+[uCOSII]: ./uCOSII/README_zh.md

--- a/TTGO_T_Display/RT-Thread/README.md
+++ b/TTGO_T_Display/RT-Thread/README.md
@@ -113,6 +113,24 @@ When all set, flash the binary with:
 ```bash
 make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
 ```
+
+> Still unable to connect to the board? Try re-flashing its firmware via its DFU bootloader.
+> 
+> Download the firmware from here: https://github.com/Xinyuan-LilyGO/LilyGO-T-DisplayGD32/raw/refs/heads/master/firmware/GD32V_CBT6_20200116.bin
+> 
+> Press the BOOT button while plugging in the board to enter DFU mode. `lsusb` should show something like:
+> 
+> ```shell
+> Bus 001 Device 047: ID 28e9:0189 GDMicroelectronics GD32 DFU Bootloader (Longan Nano)
+> # "Longan Nano" is intended behavior
+> ```
+
+> Flash the firmware with `gd32-dfu-utils` (https://github.com/riscv-mcu/gd32-dfu-utils):
+> 
+> ```shell
+> sudo gd32-dfu-util -D GD32V_CBT6_20200116.bin
+> ```
+
 ### System Startup
 
 Connect to the development board via the serial port.

--- a/TTGO_T_Display/RT-Thread/README.md
+++ b/TTGO_T_Display/RT-Thread/README.md
@@ -1,0 +1,182 @@
+---
+sys: rtthread
+sys_ver: null
+sys_var: null
+
+status: basic
+last_update: 2025-02-24
+---
+
+# RT-Thread TTGO T-Display-GD32 Test Report
+
+## Test Environment
+
+### Operating System Information
+
+- Source Code Link: https://github.com/Nuclei-Software/nuclei-sdk
+- Reference Installation Document: https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_t_display.html
+- Download Links:
+    - SDK: https://github.com/Nuclei-Software/nuclei-sdk
+    - Toolchain: https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+    - OpenOCD: https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+
+### Hardware Information
+
+- TTGO T-Display-GD32
+- A USB to UART Debugger
+- **JTAG Debugger**
+- A Type-C Cable
+
+## Installation Steps
+
+### Environment Setup
+
+Download and extract the toolchain and OpenOCD, then set up the toolchain directory:
+```bash
+wget https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+tar -xjvf nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+wget https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+tar -xzvf nuclei-openocd-2024.02.28-linux-x64.tgz
+export NUCLEI_TOOL_ROOT=$(pwd)
+```
+
+Download the SDK:
+```bash
+git clone https://github.com/Nuclei-Software/nuclei-sdk.git
+cd nuclei-sdk
+echo "NUCLEI_TOOL_ROOT=$(echo $NUCLEI_TOOL_ROOT)" > setup_config.sh
+source setup.sh
+```
+
+### Compiling the Code
+
+Compile RT-Thread:
+```bash
+cd application/rtthread/msh
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display clean
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display all
+```
+
+### Flashing the Image
+
+Connect to the development board via your JTAG debugger. Note that the board should be powered on while flashing.
+
+Make sure your debugger and OpenOCD binary is supported by the build system.
+For the former, consider editing relevant settings in `../../../SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg` to match your JTAG debugger.
+e.g. with Sipeed SLogic Combo 8 debugger at DAP-Link mode:
+```diff
+diff --git a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+index 019218da..66895b18 100644
+--- a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
++++ b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+@@ -2,8 +2,8 @@ adapter speed     5000
+ reset_config    srst_only
+ adapter srst pulse_width 100
+ 
+-adapter driver ftdi
+-ftdi vid_pid 0x0403 0x6010
++adapter driver cmsis-dap
++cmsis-dap vid_pid 0xd6e7 0x3507
+ 
+ ## bindto 0.0.0.0 can be used to cover all available interfaces.
+ ## Uncomment bindto line to enable remote machine debug
+@@ -25,14 +25,14 @@ if { [ info exists JTAGSN ] } {
+     adapter serial $JTAGSN
+ }
+ 
+-ftdi layout_init 0x0008 0x001b
+-ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
++#ftdi layout_init 0x0008 0x001b
++#ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
+ # These signals are used for cJTAG escape sequence on initialization only
+-ftdi layout_signal TCK -data 0x0001
+-ftdi layout_signal TDI -data 0x0002
+-ftdi layout_signal TDO -input 0x0004
+-ftdi layout_signal TMS -data 0x0008
+-ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
++#ftdi layout_signal TCK -data 0x0001
++#ftdi layout_signal TDI -data 0x0002
++#ftdi layout_signal TDO -input 0x0004
++#ftdi layout_signal TMS -data 0x0008
++#ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
+ transport select jtag
+ 
+ set _CHIPNAME riscv
+```
+
+Also adding an udev rule if necessary (refer to https://github.com/arduino/OpenOCD/blob/master/contrib/60-openocd.rules)
+For the latter, make sure your OpenOCD version is up to date with support for your debugger; a known usable version is at https://github.com/xpack-dev-tools/openocd-xpack/releases/tag/v0.12.0-4
+
+When all set, flash the binary with:
+```bash
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
+```
+### System Startup
+
+Connect to the development board via the serial port.
+
+## Expected Results
+
+The system should boot up normally, and information should be viewable via the onboard serial port.
+
+## Actual Results
+
+The system booted up normally, and information are viewable via the onboard serial port.
+
+### Boot Log
+
+```log
+Nuclei SDK Build Time: Feb 24 2025, 15:55:05
+Download Mode: FLASHXIP
+CPU Frequency 108000000 Hz
+
+ \ | /
+- RT -     Thread Operating System
+ / | \     3.1.5 build Feb 24 2025
+ 2006 - 2020 Copyright by rt-thread team
+Hello RT-Thread!
+msh >help 
+RT-Thread shell commands:
+list_timer       - list timer in system
+list_mailbox     - list mail box in system
+list_sem         - list semaphore in system
+list_thread      - list thread
+version          - show RT-Thread version information
+ps               - List threads in the system.
+help             - RT-Thread shell help.
+nsdk             - msh nuclei sdk demo
+
+msh >list_timer
+timer     periodic   timeout       flag
+-------- ---------- ---------- -----------
+tshell   0x00000000 0x00000000 deactivated
+tidle    0x00000000 0x00000000 deactivated
+main     0x0000000a 0x0000035d activated
+current tick:0x00000354
+msh >list_mailbox
+mailbox  entry size suspend thread
+-------- ----  ---- --------------
+msh >ps
+thread   pri  status      sp     stack size max used left tick  error
+-------- ---  ------- ---------- ----------  ------  ---------- ---
+tshell     6  ready   0x000000d8 0x00001000    10%   0x00000009 000
+tidle      7  ready   0x00000078 0x00000200    23%   0x00000020 000
+main       2  suspend 0x000000b8 0x00000400    17%   0x00000013 000
+msh >nsdk
+Hello Nuclei SDK!
+msh >
+
+```
+
+## Test Criteria
+
+Successful: The actual result matches the expected result.
+
+Failed: The actual result does not match the expected result.
+
+## Test Conclusion
+
+Test successful.
+

--- a/TTGO_T_Display/RT-Thread/README_zh.md
+++ b/TTGO_T_Display/RT-Thread/README_zh.md
@@ -105,6 +105,23 @@ index 019218da..66895b18 100644
 make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
 ```
 
+> 如果还是无法连接到开发板，可尝试重新烧写其固件进DFU。
+> 
+> 从这里下载固件：https://github.com/Xinyuan-LilyGO/LilyGO-T-DisplayGD32/raw/refs/heads/master/firmware/GD32V_CBT6_20200116.bin
+> 
+> 按住开发板上的 BOOT 按钮的同时上电，进入 DFU 模式，此时 `lsusb` 应有例如：
+> 
+> ```shell
+> Bus 001 Device 047: ID 28e9:0189 GDMicroelectronics GD32 DFU Bootloader (Longan Nano)
+> # 显示 Longan Nano 为正常现象
+> ```
+
+> 使用 `gd32-dfu-utils` (https://github.com/riscv-mcu/gd32-dfu-utils) 烧写固件：
+> 
+> ```shell
+> sudo gd32-dfu-util -D GD32V_CBT6_20200116.bin
+> ```
+
 ### 启动系统
 
 通过串口连接开发板。

--- a/TTGO_T_Display/RT-Thread/README_zh.md
+++ b/TTGO_T_Display/RT-Thread/README_zh.md
@@ -1,0 +1,173 @@
+# RT-Thread TTGO T-Display-GD32 测试报告
+
+## 测试环境
+
+### 操作系统信息
+
+- 源码链接：https://github.com/Nuclei-Software/nuclei-sdk
+- 参考文档：https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_t_display.html
+- 下载链接：
+    - SDK：https://github.com/Nuclei-Software/nuclei-sdk
+    - toolchain：https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+    - openocd：https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+
+### 硬件信息
+
+- TTGO T-Display-GD32
+- USB to UART 调试器一个
+- **JTAG 调试器**
+- type-c 线一根
+
+## 安装步骤
+
+### 配置环境
+
+下载工具链和 OpenOCD 并解压，设置工具链目录：
+```bash
+wget https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+tar -xjvf nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+wget https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+tar -xzvf nuclei-openocd-2024.02.28-linux-x64.tgz
+export NUCLEI_TOOL_ROOT=$(pwd)
+```
+
+下载 SDK：
+```bash
+git clone https://github.com/Nuclei-Software/nuclei-sdk.git
+cd nuclei-sdk
+echo "NUCLEI_TOOL_ROOT=$(echo $NUCLEI_TOOL_ROOT)" > setup_config.sh
+source setup.sh
+```
+
+### 编译代码
+
+编译 RT-Thread:
+```bash
+cd application/rtthread/msh
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display clean
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display all
+```
+
+### 烧写镜像
+
+通过 JTAG 调试器连接开发板。注意刷写期间板子需上电。
+
+请确保所使用的调试器和 OpenOCD 版本和编译系统兼容。对于前者，可在 `../../../SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg` 参考所使用的调试器种类编辑相应的 OpenOCD 参数。
+例如，使用 Sipeed SLogic Combo 8 调试器 （DAP-Link 模式）时:
+```diff
+diff --git a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+index 019218da..66895b18 100644
+--- a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
++++ b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+@@ -2,8 +2,8 @@ adapter speed     5000
+ reset_config    srst_only
+ adapter srst pulse_width 100
+ 
+-adapter driver ftdi
+-ftdi vid_pid 0x0403 0x6010
++adapter driver cmsis-dap
++cmsis-dap vid_pid 0xd6e7 0x3507
+ 
+ ## bindto 0.0.0.0 can be used to cover all available interfaces.
+ ## Uncomment bindto line to enable remote machine debug
+@@ -25,14 +25,14 @@ if { [ info exists JTAGSN ] } {
+     adapter serial $JTAGSN
+ }
+ 
+-ftdi layout_init 0x0008 0x001b
+-ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
++#ftdi layout_init 0x0008 0x001b
++#ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
+ # These signals are used for cJTAG escape sequence on initialization only
+-ftdi layout_signal TCK -data 0x0001
+-ftdi layout_signal TDI -data 0x0002
+-ftdi layout_signal TDO -input 0x0004
+-ftdi layout_signal TMS -data 0x0008
+-ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
++#ftdi layout_signal TCK -data 0x0001
++#ftdi layout_signal TDI -data 0x0002
++#ftdi layout_signal TDO -input 0x0004
++#ftdi layout_signal TMS -data 0x0008
++#ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
+ transport select jtag
+ 
+ set _CHIPNAME riscv
+```
+如有必要可添加对应的 udev 规则 （参考 https://github.com/arduino/OpenOCD/blob/master/contrib/60-openocd.rules）。
+
+对于后者，工具链中提供的 OpenOCD 版本可能不兼容某些种类的调试器。一个已知可用的版本在 https://github.com/xpack-dev-tools/openocd-xpack/releases/tag/v0.12.0-4 。
+
+准备就绪后，使用如下命令烧写：
+
+```bash
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
+```
+
+### 启动系统
+
+通过串口连接开发板。
+
+## 预期结果
+
+系统正常启动，能够通过板载串口查看信息。
+
+## 实际结果
+
+系统正常启动，能够通过板载串口查看信息。
+
+### 启动信息
+
+```log
+Nuclei SDK Build Time: Feb 24 2025, 15:55:05
+Download Mode: FLASHXIP
+CPU Frequency 108000000 Hz
+
+ \ | /
+- RT -     Thread Operating System
+ / | \     3.1.5 build Feb 24 2025
+ 2006 - 2020 Copyright by rt-thread team
+Hello RT-Thread!
+msh >help 
+RT-Thread shell commands:
+list_timer       - list timer in system
+list_mailbox     - list mail box in system
+list_sem         - list semaphore in system
+list_thread      - list thread
+version          - show RT-Thread version information
+ps               - List threads in the system.
+help             - RT-Thread shell help.
+nsdk             - msh nuclei sdk demo
+
+msh >list_timer
+timer     periodic   timeout       flag
+-------- ---------- ---------- -----------
+tshell   0x00000000 0x00000000 deactivated
+tidle    0x00000000 0x00000000 deactivated
+main     0x0000000a 0x0000035d activated
+current tick:0x00000354
+msh >list_mailbox
+mailbox  entry size suspend thread
+-------- ----  ---- --------------
+msh >ps
+thread   pri  status      sp     stack size max used left tick  error
+-------- ---  ------- ---------- ----------  ------  ---------- ---
+tshell     6  ready   0x000000d8 0x00001000    10%   0x00000009 000
+tidle      7  ready   0x00000078 0x00000200    23%   0x00000020 000
+main       2  suspend 0x000000b8 0x00000400    17%   0x00000013 000
+msh >nsdk
+Hello Nuclei SDK!
+msh >
+
+```
+
+## 测试判定标准
+
+测试成功：实际结果与预期结果相符。
+
+测试失败：实际结果与预期结果不符。
+
+## 测试结论
+
+测试成功。

--- a/TTGO_T_Display/ThreadX/README.md
+++ b/TTGO_T_Display/ThreadX/README.md
@@ -113,6 +113,24 @@ When all set, flash the binary with:
 ```bash
 make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
 ```
+
+> Still unable to connect to the board? Try re-flashing its firmware via its DFU bootloader.
+> 
+> Download the firmware from here: https://github.com/Xinyuan-LilyGO/LilyGO-T-DisplayGD32/raw/refs/heads/master/firmware/GD32V_CBT6_20200116.bin
+> 
+> Press the BOOT button while plugging in the board to enter DFU mode. `lsusb` should show something like:
+> 
+> ```shell
+> Bus 001 Device 047: ID 28e9:0189 GDMicroelectronics GD32 DFU Bootloader (Longan Nano)
+> # "Longan Nano" is intended behavior
+> ```
+
+> Flash the firmware with `gd32-dfu-utils` (https://github.com/riscv-mcu/gd32-dfu-utils):
+> 
+> ```shell
+> sudo gd32-dfu-util -D GD32V_CBT6_20200116.bin
+> ```
+
 ### System Startup
 
 Connect to the development board via the serial port.

--- a/TTGO_T_Display/ThreadX/README.md
+++ b/TTGO_T_Display/ThreadX/README.md
@@ -1,0 +1,214 @@
+---
+sys: threadx
+sys_ver: null
+sys_var: null
+
+status: basic
+last_update: 2025-02-24
+---
+
+# ThreadX TTGO T-Display-GD32 Test Report
+
+## Test Environment
+
+### Operating System Information
+
+- Source Code Link: https://github.com/Nuclei-Software/nuclei-sdk
+- Reference Installation Document: https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_t_display.html
+- Download Links:
+    - SDK: https://github.com/Nuclei-Software/nuclei-sdk
+    - Toolchain: https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+    - OpenOCD: https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+
+### Hardware Information
+
+- TTGO T-Display-GD32
+- A USB to UART Debugger
+- **JTAG Debugger**
+- A Type-C Cable
+
+## Installation Steps
+
+### Environment Setup
+
+Download and extract the toolchain and OpenOCD, then set up the toolchain directory:
+```bash
+wget https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+tar -xjvf nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+wget https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+tar -xzvf nuclei-openocd-2024.02.28-linux-x64.tgz
+export NUCLEI_TOOL_ROOT=$(pwd)
+```
+
+Download the SDK:
+```bash
+git clone https://github.com/Nuclei-Software/nuclei-sdk.git
+cd nuclei-sdk
+echo "NUCLEI_TOOL_ROOT=$(echo $NUCLEI_TOOL_ROOT)" > setup_config.sh
+source setup.sh
+```
+
+### Compiling the Code
+
+Compile ThreadX:
+```bash
+cd application/threadx/demo
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display clean
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display all
+```
+
+### Flashing the Image
+
+Connect to the development board via your JTAG debugger. Note that the board should be powered on while flashing.
+
+Make sure your debugger and OpenOCD binary is supported by the build system.
+For the former, consider editing relevant settings in `../../../SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg` to match your JTAG debugger.
+e.g. with Sipeed SLogic Combo 8 debugger at DAP-Link mode:
+```diff
+diff --git a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+index 019218da..66895b18 100644
+--- a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
++++ b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+@@ -2,8 +2,8 @@ adapter speed     5000
+ reset_config    srst_only
+ adapter srst pulse_width 100
+ 
+-adapter driver ftdi
+-ftdi vid_pid 0x0403 0x6010
++adapter driver cmsis-dap
++cmsis-dap vid_pid 0xd6e7 0x3507
+ 
+ ## bindto 0.0.0.0 can be used to cover all available interfaces.
+ ## Uncomment bindto line to enable remote machine debug
+@@ -25,14 +25,14 @@ if { [ info exists JTAGSN ] } {
+     adapter serial $JTAGSN
+ }
+ 
+-ftdi layout_init 0x0008 0x001b
+-ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
++#ftdi layout_init 0x0008 0x001b
++#ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
+ # These signals are used for cJTAG escape sequence on initialization only
+-ftdi layout_signal TCK -data 0x0001
+-ftdi layout_signal TDI -data 0x0002
+-ftdi layout_signal TDO -input 0x0004
+-ftdi layout_signal TMS -data 0x0008
+-ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
++#ftdi layout_signal TCK -data 0x0001
++#ftdi layout_signal TDI -data 0x0002
++#ftdi layout_signal TDO -input 0x0004
++#ftdi layout_signal TMS -data 0x0008
++#ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
+ transport select jtag
+ 
+ set _CHIPNAME riscv
+```
+
+Also adding an udev rule if necessary (refer to https://github.com/arduino/OpenOCD/blob/master/contrib/60-openocd.rules)
+For the latter, make sure your OpenOCD version is up to date with support for your debugger; a known usable version is at https://github.com/xpack-dev-tools/openocd-xpack/releases/tag/v0.12.0-4
+
+When all set, flash the binary with:
+```bash
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
+```
+### System Startup
+
+Connect to the development board via the serial port.
+
+## Expected Results
+
+The system should boot up normally, and information should be viewable via the onboard serial port.
+
+## Actual Results
+
+The system booted up normally, and information are viewable via the onboard serial port.
+
+### Boot Log
+
+```log
+Nuclei SDK Build Time: Feb 24 2025, 16:00:38
+Download Mode: FLASHXIP
+CPU Frequency 108000000 Hz
+thread 6_7 is running, current is 6, thread 6 counter 1, thread 7 counter 1
+thread 6_7 is running, current is 7, thread 6 counter 2, thread 7 counter 1
+thread 6_7 is running, current is 6, thread 6 counter 2, thread 7 counter 2
+thread 6_7 is running, current is 7, thread 6 counter 3, thread 7 counter 2
+thread 6_7 is running, current is 6, thread 6 counter 3, thread 7 counter 3
+thread 6_7 is running, current is 7, thread 6 counter 4, thread 7 counter 3
+thread 6_7 is running, current is 6, thread 6 counter 4, thread 7 counter 4
+thread 6_7 is running, current is 7, thread 6 counter 5, thread 7 counter 4
+thread 6_7 is running, current is 6, thread 6 counter 5, thread 7 counter 5
+thread 6_7 is running, current is 7, thread 6 counter 6, thread 7 counter 5
+thread 6_7 is running, current is 6, thread 6 counter 6, thread 7 counter 6
+thread 6_7 is running, current is 7, thread 6 counter 7, thread 7 counter 6
+thread 6_7 is running, current is 6, thread 6 counter 7, thread 7 counter 7
+thread 6_7 is running, current is 7, thread 6 counter 8, thread 7 counter 7
+thread 6_7 is running, current is 6, thread 6 counter 8, thread 7 counter 8
+thread 6_7 is running, current is 7, thread 6 counter 9, thread 7 counter 8
+thread 6_7 is running, current is 6, thread 6 counter 9, thread 7 counter 9
+thread 6_7 is running, current is 7, thread 6 counter 10, thread 7 counter 9
+thread 6_7 is running, current is 6, thread 6 counter 10, thread 7 counter 10
+thread 6_7 is running, current is 7, thread 6 counter 11, thread 7 counter 10
+thread 6_7 is running, current is 6, thread 6 counter 11, thread 7 counter 11
+thread 6_7 is running, current is 7, thread 6 counter 12, thread 7 counter 11
+thread 6_7 is running, current is 6, thread 6 counter 12, thread 7 counter 12
+thread 6_7 is running, current is 7, thread 6 counter 13, thread 7 counter 12
+thread 6_7 is running, current is 6, thread 6 counter 13, thread 7 counter 13
+thread 6_7 is running, current is 7, thread 6 counter 14, thread 7 counter 13
+thread 6_7 is running, current is 6, thread 6 counter 14, thread 7 counter 14
+thread 6_7 is running, current is 7, thread 6 counter 15, thread 7 counter 14
+thread 6_7 is running, current is 6, thread 6 counter 15, thread 7 counter 15
+thread 6_7 is running, current is 7, thread 6 counter 16, thread 7 counter 15
+thread 6_7 is running, current is 6, thread 6 counter 16, thread 7 counter 16
+thread 6_7 is running, current is 7, thread 6 counter 17, thread 7 counter 16
+thread 6_7 is running, current is 6, thread 6 counter 17, thread 7 counter 17
+thread 6_7 is running, current is 7, thread 6 counter 18, thread 7 counter 17
+thread 6_7 is running, current is 6, thread 6 counter 18, thread 7 counter 18
+thread 6_7 is running, current is 7, thread 6 counter 19, thread 7 counter 18
+thread 6_7 is running, current is 6, thread 6 counter 19, thread 7 counter 19
+thread 6_7 is running, current is 7, thread 6 counter 20, thread 7 counter 19
+thread 6_7 is running, current is 6, thread 6 counter 20, thread 7 counter 20
+thread 6_7 is running, current is 7, thread 6 counter 21, thread 7 counter 20
+thread 6_7 is running, current is 6, thread 6 counter 21, thread 7 counter 21
+thread 6_7 is running, current is 7, thread 6 counter 22, thread 7 counter 21
+thread 6_7 is running, current is 6, thread 6 counter 22, thread 7 counter 22
+thread 6_7 is running, current is 7, thread 6 counter 23, thread 7 counter 22
+thread 6_7 is running, current is 6, thread 6 counter 23, thread 7 counter 23
+thread 6_7 is running, current is 7, thread 6 counter 24, thread 7 counter 23
+thread 6_7 is running, current is 6, thread 6 counter 24, thread 7 counter 24
+thread 6_7 is running, current is 7, thread 6 counter 25, thread 7 counter 24
+thread 6_7 is running, current is 6, thread 6 counter 25, thread 7 counter 25
+thread 6_7 is running, current is 7, thread 6 counter 26, thread 7 counter 25
+thread 6_7 is running, current is 6, thread 6 counter 26, thread 7 counter 26
+thread 6_7 is running, current is 7, thread 6 counter 27, thread 7 counter 26
+thread 6_7 is running, current is 6, thread 6 counter 27, thread 7 counter 27
+thread 6_7 is running, current is 7, thread 6 counter 28, thread 7 counter 27
+thread 6_7 is running, current is 6, thread 6 counter 28, thread 7 counter 28
+thread 6_7 is running, current is 7, thread 6 counter 29, thread 7 counter 28
+thread 6_7 is running, current is 6, thread 6 counter 29, thread 7 counter 29
+thread 6_7 is running, current is 7, thread 6 counter 30, thread 7 counter 29
+thread 6_7 is running, current is 6, thread 6 counter 30, thread 7 counter 30
+thread 6_7 is running, current is 7, thread 6 counter 31, thread 7 counter 30
+thread 6_7 is running, current is 6, thread 6 counter 31, thread 7 counter 31
+thread 6_7 is running, current is 7, thread 6 counter 32, thread 7 counter 31
+thread 6_7 is running, current is 6, thread 6 counter 32, thread 7 counter 32
+thread 6_7 is running, current is 7, thread 6 counter 33, thread 7 counter 32
+
+...
+
+(truncated)
+
+```
+
+## Test Criteria
+
+Successful: The actual result matches the expected result.
+
+Failed: The actual result does not match the expected result.
+
+## Test Conclusion
+
+Test successful.
+

--- a/TTGO_T_Display/ThreadX/README_zh.md
+++ b/TTGO_T_Display/ThreadX/README_zh.md
@@ -105,6 +105,23 @@ index 019218da..66895b18 100644
 make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
 ```
 
+> 如果还是无法连接到开发板，可尝试重新烧写其固件进DFU。
+> 
+> 从这里下载固件：https://github.com/Xinyuan-LilyGO/LilyGO-T-DisplayGD32/raw/refs/heads/master/firmware/GD32V_CBT6_20200116.bin
+> 
+> 按住开发板上的 BOOT 按钮的同时上电，进入 DFU 模式，此时 `lsusb` 应有例如：
+> 
+> ```shell
+> Bus 001 Device 047: ID 28e9:0189 GDMicroelectronics GD32 DFU Bootloader (Longan Nano)
+> # 显示 Longan Nano 为正常现象
+> ```
+
+> 使用 `gd32-dfu-utils` (https://github.com/riscv-mcu/gd32-dfu-utils) 烧写固件：
+> 
+> ```shell
+> sudo gd32-dfu-util -D GD32V_CBT6_20200116.bin
+> ```
+
 ### 启动系统
 
 通过串口连接开发板。

--- a/TTGO_T_Display/ThreadX/README_zh.md
+++ b/TTGO_T_Display/ThreadX/README_zh.md
@@ -1,0 +1,202 @@
+# ThreadX TTGO T-Display-GD32 测试报告
+
+## 测试环境
+
+### 操作系统信息
+
+- 源码链接：https://github.com/Nuclei-Software/nuclei-sdk
+- 参考文档：https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_t_display.html
+- 下载链接：
+    - SDK：https://github.com/Nuclei-Software/nuclei-sdk
+    - toolchain：https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+    - openocd：https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+
+### 硬件信息
+
+- TTGO T-Display-GD32
+- USB to UART 调试器一个
+- **JTAG 调试器**
+- type-c 线一根
+
+## 安装步骤
+
+### 配置环境
+
+下载工具链和 OpenOCD 并解压，设置工具链目录：
+```bash
+wget https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+tar -xjvf nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+wget https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+tar -xzvf nuclei-openocd-2024.02.28-linux-x64.tgz
+export NUCLEI_TOOL_ROOT=$(pwd)
+```
+
+下载 SDK：
+```bash
+git clone https://github.com/Nuclei-Software/nuclei-sdk.git
+cd nuclei-sdk
+echo "NUCLEI_TOOL_ROOT=$(echo $NUCLEI_TOOL_ROOT)" > setup_config.sh
+source setup.sh
+```
+
+### 编译代码
+
+编译 ThreadX:
+```bash
+cd application/threadx/demo
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display clean
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display all
+```
+
+### 烧写镜像
+
+通过 JTAG 调试器连接开发板。注意刷写期间板子需上电。
+
+请确保所使用的调试器和 OpenOCD 版本和编译系统兼容。对于前者，可在 `../../../SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg` 参考所使用的调试器种类编辑相应的 OpenOCD 参数。
+例如，使用 Sipeed SLogic Combo 8 调试器 （DAP-Link 模式）时:
+```diff
+diff --git a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+index 019218da..66895b18 100644
+--- a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
++++ b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+@@ -2,8 +2,8 @@ adapter speed     5000
+ reset_config    srst_only
+ adapter srst pulse_width 100
+ 
+-adapter driver ftdi
+-ftdi vid_pid 0x0403 0x6010
++adapter driver cmsis-dap
++cmsis-dap vid_pid 0xd6e7 0x3507
+ 
+ ## bindto 0.0.0.0 can be used to cover all available interfaces.
+ ## Uncomment bindto line to enable remote machine debug
+@@ -25,14 +25,14 @@ if { [ info exists JTAGSN ] } {
+     adapter serial $JTAGSN
+ }
+ 
+-ftdi layout_init 0x0008 0x001b
+-ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
++#ftdi layout_init 0x0008 0x001b
++#ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
+ # These signals are used for cJTAG escape sequence on initialization only
+-ftdi layout_signal TCK -data 0x0001
+-ftdi layout_signal TDI -data 0x0002
+-ftdi layout_signal TDO -input 0x0004
+-ftdi layout_signal TMS -data 0x0008
+-ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
++#ftdi layout_signal TCK -data 0x0001
++#ftdi layout_signal TDI -data 0x0002
++#ftdi layout_signal TDO -input 0x0004
++#ftdi layout_signal TMS -data 0x0008
++#ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
+ transport select jtag
+ 
+ set _CHIPNAME riscv
+```
+如有必要可添加对应的 udev 规则 （参考 https://github.com/arduino/OpenOCD/blob/master/contrib/60-openocd.rules）。
+
+对于后者，工具链中提供的 OpenOCD 版本可能不兼容某些种类的调试器。一个已知可用的版本在 https://github.com/xpack-dev-tools/openocd-xpack/releases/tag/v0.12.0-4 。
+
+准备就绪后，使用如下命令烧写：
+
+```bash
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
+```
+
+### 启动系统
+
+通过串口连接开发板。
+
+## 预期结果
+
+系统正常启动，能够通过板载串口查看信息。
+
+## 实际结果
+
+系统正常启动，能够通过板载串口查看信息。
+
+### 启动信息
+
+```log
+Nuclei SDK Build Time: Feb 24 2025, 16:00:38
+Download Mode: FLASHXIP
+CPU Frequency 108000000 Hz
+thread 6_7 is running, current is 6, thread 6 counter 1, thread 7 counter 1
+thread 6_7 is running, current is 7, thread 6 counter 2, thread 7 counter 1
+thread 6_7 is running, current is 6, thread 6 counter 2, thread 7 counter 2
+thread 6_7 is running, current is 7, thread 6 counter 3, thread 7 counter 2
+thread 6_7 is running, current is 6, thread 6 counter 3, thread 7 counter 3
+thread 6_7 is running, current is 7, thread 6 counter 4, thread 7 counter 3
+thread 6_7 is running, current is 6, thread 6 counter 4, thread 7 counter 4
+thread 6_7 is running, current is 7, thread 6 counter 5, thread 7 counter 4
+thread 6_7 is running, current is 6, thread 6 counter 5, thread 7 counter 5
+thread 6_7 is running, current is 7, thread 6 counter 6, thread 7 counter 5
+thread 6_7 is running, current is 6, thread 6 counter 6, thread 7 counter 6
+thread 6_7 is running, current is 7, thread 6 counter 7, thread 7 counter 6
+thread 6_7 is running, current is 6, thread 6 counter 7, thread 7 counter 7
+thread 6_7 is running, current is 7, thread 6 counter 8, thread 7 counter 7
+thread 6_7 is running, current is 6, thread 6 counter 8, thread 7 counter 8
+thread 6_7 is running, current is 7, thread 6 counter 9, thread 7 counter 8
+thread 6_7 is running, current is 6, thread 6 counter 9, thread 7 counter 9
+thread 6_7 is running, current is 7, thread 6 counter 10, thread 7 counter 9
+thread 6_7 is running, current is 6, thread 6 counter 10, thread 7 counter 10
+thread 6_7 is running, current is 7, thread 6 counter 11, thread 7 counter 10
+thread 6_7 is running, current is 6, thread 6 counter 11, thread 7 counter 11
+thread 6_7 is running, current is 7, thread 6 counter 12, thread 7 counter 11
+thread 6_7 is running, current is 6, thread 6 counter 12, thread 7 counter 12
+thread 6_7 is running, current is 7, thread 6 counter 13, thread 7 counter 12
+thread 6_7 is running, current is 6, thread 6 counter 13, thread 7 counter 13
+thread 6_7 is running, current is 7, thread 6 counter 14, thread 7 counter 13
+thread 6_7 is running, current is 6, thread 6 counter 14, thread 7 counter 14
+thread 6_7 is running, current is 7, thread 6 counter 15, thread 7 counter 14
+thread 6_7 is running, current is 6, thread 6 counter 15, thread 7 counter 15
+thread 6_7 is running, current is 7, thread 6 counter 16, thread 7 counter 15
+thread 6_7 is running, current is 6, thread 6 counter 16, thread 7 counter 16
+thread 6_7 is running, current is 7, thread 6 counter 17, thread 7 counter 16
+thread 6_7 is running, current is 6, thread 6 counter 17, thread 7 counter 17
+thread 6_7 is running, current is 7, thread 6 counter 18, thread 7 counter 17
+thread 6_7 is running, current is 6, thread 6 counter 18, thread 7 counter 18
+thread 6_7 is running, current is 7, thread 6 counter 19, thread 7 counter 18
+thread 6_7 is running, current is 6, thread 6 counter 19, thread 7 counter 19
+thread 6_7 is running, current is 7, thread 6 counter 20, thread 7 counter 19
+thread 6_7 is running, current is 6, thread 6 counter 20, thread 7 counter 20
+thread 6_7 is running, current is 7, thread 6 counter 21, thread 7 counter 20
+thread 6_7 is running, current is 6, thread 6 counter 21, thread 7 counter 21
+thread 6_7 is running, current is 7, thread 6 counter 22, thread 7 counter 21
+thread 6_7 is running, current is 6, thread 6 counter 22, thread 7 counter 22
+thread 6_7 is running, current is 7, thread 6 counter 23, thread 7 counter 22
+thread 6_7 is running, current is 6, thread 6 counter 23, thread 7 counter 23
+thread 6_7 is running, current is 7, thread 6 counter 24, thread 7 counter 23
+thread 6_7 is running, current is 6, thread 6 counter 24, thread 7 counter 24
+thread 6_7 is running, current is 7, thread 6 counter 25, thread 7 counter 24
+thread 6_7 is running, current is 6, thread 6 counter 25, thread 7 counter 25
+thread 6_7 is running, current is 7, thread 6 counter 26, thread 7 counter 25
+thread 6_7 is running, current is 6, thread 6 counter 26, thread 7 counter 26
+thread 6_7 is running, current is 7, thread 6 counter 27, thread 7 counter 26
+thread 6_7 is running, current is 6, thread 6 counter 27, thread 7 counter 27
+thread 6_7 is running, current is 7, thread 6 counter 28, thread 7 counter 27
+thread 6_7 is running, current is 6, thread 6 counter 28, thread 7 counter 28
+thread 6_7 is running, current is 7, thread 6 counter 29, thread 7 counter 28
+thread 6_7 is running, current is 6, thread 6 counter 29, thread 7 counter 29
+thread 6_7 is running, current is 7, thread 6 counter 30, thread 7 counter 29
+thread 6_7 is running, current is 6, thread 6 counter 30, thread 7 counter 30
+thread 6_7 is running, current is 7, thread 6 counter 31, thread 7 counter 30
+thread 6_7 is running, current is 6, thread 6 counter 31, thread 7 counter 31
+thread 6_7 is running, current is 7, thread 6 counter 32, thread 7 counter 31
+thread 6_7 is running, current is 6, thread 6 counter 32, thread 7 counter 32
+thread 6_7 is running, current is 7, thread 6 counter 33, thread 7 counter 32
+... (truncated)
+
+```
+
+## 测试判定标准
+
+测试成功：实际结果与预期结果相符。
+
+测试失败：实际结果与预期结果不符。
+
+## 测试结论
+
+测试成功。

--- a/TTGO_T_Display/uCOSII/README.md
+++ b/TTGO_T_Display/uCOSII/README.md
@@ -115,6 +115,23 @@ When all set, flash the binary with:
 make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
 ```
 
+> Still unable to connect to the board? Try re-flashing its firmware via its DFU bootloader.
+> 
+> Download the firmware from here: https://github.com/Xinyuan-LilyGO/LilyGO-T-DisplayGD32/raw/refs/heads/master/firmware/GD32V_CBT6_20200116.bin
+> 
+> Press the BOOT button while plugging in the board to enter DFU mode. `lsusb` should show something like:
+> 
+> ```shell
+> Bus 001 Device 047: ID 28e9:0189 GDMicroelectronics GD32 DFU Bootloader (Longan Nano)
+> # "Longan Nano" is intended behavior
+> ```
+
+> Flash the firmware with `gd32-dfu-utils` (https://github.com/riscv-mcu/gd32-dfu-utils):
+> 
+> ```shell
+> sudo gd32-dfu-util -D GD32V_CBT6_20200116.bin
+> ```
+
 ### Start System
 
 Connect to the development board via serial port.

--- a/TTGO_T_Display/uCOSII/README.md
+++ b/TTGO_T_Display/uCOSII/README.md
@@ -1,0 +1,202 @@
+---
+sys: ucosii
+sys_ver: null
+sys_var: null
+
+status: basic
+last_update: 2025-02-24
+---
+
+# μC/OS-II TTGO T-Display-GD32 Test Report
+
+## Test Environment
+
+### Operating System Information
+
+- Source Code Link: https://github.com/Nuclei-Software/nuclei-sdk
+- Reference Installation Document: https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_t_display.html
+- Download Links:
+    - SDK: https://github.com/Nuclei-Software/nuclei-sdk
+    - Toolchain: https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+    - OpenOCD: https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+
+### Hardware Information
+
+- TTGO T-Display-GD32
+- A USB to UART Debugger
+- **JTAG Debugger**
+- A Type-C Cable
+
+## Installation Steps
+
+### Configure Environment
+
+Download and extract the toolchain and OpenOCD, then set the toolchain directory:
+```bash
+wget https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+tar -xjvf nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+wget https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+tar -xzvf nuclei-openocd-2024.02.28-linux-x64.tgz
+export NUCLEI_TOOL_ROOT=$(pwd)
+```
+
+Download the SDK:
+```bash
+git clone https://github.com/Nuclei-Software/nuclei-sdk.git
+cd nuclei-sdk
+echo "NUCLEI_TOOL_ROOT=$(echo $NUCLEI_TOOL_ROOT)" > setup_config.sh
+
+source setup.sh
+```
+
+### Compile Code
+
+Compile μC/OS-II:
+```bash
+cd application/ucosii/demo/
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display clean
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display all
+```
+
+### Flash Image
+
+Connect to the development board via your JTAG debugger. Note that the board should be powered on while flashing.
+
+Make sure your debugger and OpenOCD binary is supported by the build system.
+For the former, consider editing relevant settings in `../../../SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg` to match your JTAG debugger.
+e.g. with Sipeed SLogic Combo 8 debugger at DAP-Link mode:
+```diff
+diff --git a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+index 019218da..66895b18 100644
+--- a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
++++ b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+@@ -2,8 +2,8 @@ adapter speed     5000
+ reset_config    srst_only
+ adapter srst pulse_width 100
+ 
+-adapter driver ftdi
+-ftdi vid_pid 0x0403 0x6010
++adapter driver cmsis-dap
++cmsis-dap vid_pid 0xd6e7 0x3507
+ 
+ ## bindto 0.0.0.0 can be used to cover all available interfaces.
+ ## Uncomment bindto line to enable remote machine debug
+@@ -25,14 +25,14 @@ if { [ info exists JTAGSN ] } {
+     adapter serial $JTAGSN
+ }
+ 
+-ftdi layout_init 0x0008 0x001b
+-ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
++#ftdi layout_init 0x0008 0x001b
++#ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
+ # These signals are used for cJTAG escape sequence on initialization only
+-ftdi layout_signal TCK -data 0x0001
+-ftdi layout_signal TDI -data 0x0002
+-ftdi layout_signal TDO -input 0x0004
+-ftdi layout_signal TMS -data 0x0008
+-ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
++#ftdi layout_signal TCK -data 0x0001
++#ftdi layout_signal TDI -data 0x0002
++#ftdi layout_signal TDO -input 0x0004
++#ftdi layout_signal TMS -data 0x0008
++#ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
+ transport select jtag
+ 
+ set _CHIPNAME riscv
+```
+
+Also adding an udev rule if necessary (refer to https://github.com/arduino/OpenOCD/blob/master/contrib/60-openocd.rules)
+For the latter, make sure your OpenOCD version is up to date with support for your debugger; a known usable version is at https://github.com/xpack-dev-tools/openocd-xpack/releases/tag/v0.12.0-4
+
+When all set, flash the binary with:
+```bash
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
+```
+
+### Start System
+
+Connect to the development board via serial port.
+
+## Expected Results
+
+The system should boot normally and provide information via the onboard serial port.
+
+## Actual Results
+
+The system booted up normally, and information are viewable via the onboard serial port.
+
+### Boot Log
+
+```log
+Nuclei SDK Build Time: Feb 24 2025, 16:03:45
+Download Mode: FLASHXIP
+CPU Frequency 108000000 Hz
+Start ucosii...
+create start task success
+start all task...
+task3 is running... 1
+task2 is running... 1
+task1 is running... 1
+task3 is running... 2
+task2 is running... 2
+task1 is running... 2
+task3 is running... 3
+task2 is running... 3
+task3 is running... 4
+task2 is running... 4
+task1 is running... 3
+task3 is running... 5
+task2 is running... 5
+task3 is running... 6
+task2 is running... 6
+task1 is running... 4
+task3 is running... 7
+task2 is running... 7
+task3 is running... 8
+task2 is running... 8
+task1 is running... 5
+task3 is running... 9
+task2 is running... 9
+task3 is running... 10
+task2 is running... 10
+task1 is running... 6
+task3 is running... 11
+task2 is running... 11
+task3 is running... 12
+task2 is running... 12
+task1 is running... 7
+task3 is running... 13
+task2 is running... 13
+task3 is running... 14
+task2 is running... 14
+task1 is running... 8
+task3 is running... 15
+task2 is running... 15
+task3 is running... 16
+task2 is running... 16
+task1 is running... 9
+task3 is running... 17
+task2 is running... 17
+task3 is running... 18
+task2 is running... 18
+task1 is running... 10
+task3 is running... 19
+task2 is running... 19
+task3 is running... 20
+task2 is running... 20
+task1 is running... 11
+
+(truncated)
+```
+
+## Test Criteria
+
+Successful: The actual result matches the expected result.
+
+Failed: The actual result does not match the expected result.
+
+## Test Conclusion
+
+Test successful.

--- a/TTGO_T_Display/uCOSII/README_zh.md
+++ b/TTGO_T_Display/uCOSII/README_zh.md
@@ -1,0 +1,192 @@
+# μC/OS-II TTGO T-Display-GD32 测试报告
+
+## 测试环境
+
+### 操作系统信息
+
+- 源码链接：https://github.com/Nuclei-Software/nuclei-sdk
+- 参考文档：https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_t_display.html
+- 下载链接：
+    - SDK：https://github.com/Nuclei-Software/nuclei-sdk
+    - toolchain：https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+    - openocd：https://www.nucleisys.com/download.php
+        - https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+
+### 硬件信息
+
+- TTGO T-Display-GD32
+- USB to UART 调试器一个
+- **JTAG 调试器**
+- type-c 线一根
+
+## 安装步骤
+
+### 配置环境
+
+下载工具链和 OpenOCD 并解压，设置工具链目录：
+```bash
+wget https://download.nucleisys.com/upload/files/toolchain/gcc/nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+tar -xjvf nuclei_riscv_newlibc_prebuilt_linux64_nuclei-2024.tar.bz2
+wget https://download.nucleisys.com/upload/files/toolchain/openocd/nuclei-openocd-2024.02.28-linux-x64.tgz
+tar -xzvf nuclei-openocd-2024.02.28-linux-x64.tgz
+export NUCLEI_TOOL_ROOT=$(pwd)
+```
+
+下载 SDK：
+```bash
+git clone https://github.com/Nuclei-Software/nuclei-sdk.git
+cd nuclei-sdk
+echo "NUCLEI_TOOL_ROOT=$(echo $NUCLEI_TOOL_ROOT)" > setup_config.sh
+source setup.sh
+```
+
+### 编译代码
+
+编译 μC/OS-II:
+```bash
+cd application/ucosii/demo/
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display clean
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display all
+```
+
+### 烧写镜像
+
+通过 JTAG 调试器连接开发板。注意刷写期间板子需上电。
+
+请确保所使用的调试器和 OpenOCD 版本和编译系统兼容。对于前者，可在 `../../../SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg` 参考所使用的调试器种类编辑相应的 OpenOCD 参数。
+例如，使用 Sipeed SLogic Combo 8 调试器 （DAP-Link 模式）时:
+```diff
+diff --git a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+index 019218da..66895b18 100644
+--- a/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
++++ b/SoC/gd32vf103/Board/gd32vf103c_t_display/openocd_gd32vf103.cfg
+@@ -2,8 +2,8 @@ adapter speed     5000
+ reset_config    srst_only
+ adapter srst pulse_width 100
+ 
+-adapter driver ftdi
+-ftdi vid_pid 0x0403 0x6010
++adapter driver cmsis-dap
++cmsis-dap vid_pid 0xd6e7 0x3507
+ 
+ ## bindto 0.0.0.0 can be used to cover all available interfaces.
+ ## Uncomment bindto line to enable remote machine debug
+@@ -25,14 +25,14 @@ if { [ info exists JTAGSN ] } {
+     adapter serial $JTAGSN
+ }
+ 
+-ftdi layout_init 0x0008 0x001b
+-ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
++#ftdi layout_init 0x0008 0x001b
++#ftdi layout_signal nSRST -oe 0x0020 -data 0x0020
+ # These signals are used for cJTAG escape sequence on initialization only
+-ftdi layout_signal TCK -data 0x0001
+-ftdi layout_signal TDI -data 0x0002
+-ftdi layout_signal TDO -input 0x0004
+-ftdi layout_signal TMS -data 0x0008
+-ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
++#ftdi layout_signal TCK -data 0x0001
++#ftdi layout_signal TDI -data 0x0002
++#ftdi layout_signal TDO -input 0x0004
++#ftdi layout_signal TMS -data 0x0008
++#ftdi layout_signal JTAG_SEL -data 0x0100 -oe 0x0100
+ transport select jtag
+ 
+ set _CHIPNAME riscv
+```
+如有必要可添加对应的 udev 规则 （参考 https://github.com/arduino/OpenOCD/blob/master/contrib/60-openocd.rules）。
+
+对于后者，工具链中提供的 OpenOCD 版本可能不兼容某些种类的调试器。一个已知可用的版本在 https://github.com/xpack-dev-tools/openocd-xpack/releases/tag/v0.12.0-4 。
+
+准备就绪后，使用如下命令烧写：
+
+```bash
+make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
+```
+
+### 启动系统
+
+通过串口连接开发板。
+
+## 预期结果
+
+系统正常启动，能够通过板载串口查看信息。
+
+## 实际结果
+
+系统正常启动，能够通过板载串口查看信息。
+
+### 启动信息
+
+```log
+Nuclei SDK Build Time: Feb 24 2025, 16:03:45
+Download Mode: FLASHXIP
+CPU Frequency 108000000 Hz
+Start ucosii...
+create start task success
+start all task...
+task3 is running... 1
+task2 is running... 1
+task1 is running... 1
+task3 is running... 2
+task2 is running... 2
+task1 is running... 2
+task3 is running... 3
+task2 is running... 3
+task3 is running... 4
+task2 is running... 4
+task1 is running... 3
+task3 is running... 5
+task2 is running... 5
+task3 is running... 6
+task2 is running... 6
+task1 is running... 4
+task3 is running... 7
+task2 is running... 7
+task3 is running... 8
+task2 is running... 8
+task1 is running... 5
+task3 is running... 9
+task2 is running... 9
+task3 is running... 10
+task2 is running... 10
+task1 is running... 6
+task3 is running... 11
+task2 is running... 11
+task3 is running... 12
+task2 is running... 12
+task1 is running... 7
+task3 is running... 13
+task2 is running... 13
+task3 is running... 14
+task2 is running... 14
+task1 is running... 8
+task3 is running... 15
+task2 is running... 15
+task3 is running... 16
+task2 is running... 16
+task1 is running... 9
+task3 is running... 17
+task2 is running... 17
+task3 is running... 18
+task2 is running... 18
+task1 is running... 10
+task3 is running... 19
+task2 is running... 19
+task3 is running... 20
+task2 is running... 20
+task1 is running... 11
+
+(truncated)
+```
+
+## 测试判定标准
+
+测试成功：实际结果与预期结果相符。
+
+测试失败：实际结果与预期结果不符。
+
+## 测试结论
+
+测试成功。

--- a/TTGO_T_Display/uCOSII/README_zh.md
+++ b/TTGO_T_Display/uCOSII/README_zh.md
@@ -105,6 +105,23 @@ index 019218da..66895b18 100644
 make SOC=gd32vf103 BOARD=gd32vf103c_t_display upload
 ```
 
+> 如果还是无法连接到开发板，可尝试重新烧写其固件进DFU。
+> 
+> 从这里下载固件：https://github.com/Xinyuan-LilyGO/LilyGO-T-DisplayGD32/raw/refs/heads/master/firmware/GD32V_CBT6_20200116.bin
+> 
+> 按住开发板上的 BOOT 按钮的同时上电，进入 DFU 模式，此时 `lsusb` 应有例如：
+> 
+> ```shell
+> Bus 001 Device 047: ID 28e9:0189 GDMicroelectronics GD32 DFU Bootloader (Longan Nano)
+> # 显示 Longan Nano 为正常现象
+> ```
+
+> 使用 `gd32-dfu-utils` (https://github.com/riscv-mcu/gd32-dfu-utils) 烧写固件：
+> 
+> ```shell
+> sudo gd32-dfu-util -D GD32V_CBT6_20200116.bin
+> ```
+
 ### 启动系统
 
 通过串口连接开发板。

--- a/assets/metadata.yml
+++ b/assets/metadata.yml
@@ -36,6 +36,7 @@ rtos:
   - nuttx: NuttX
   - melis: Melis
   - uniproton: UniProton
+  - ucosii: μC/OS-II
 
 others:
   - android: Android


### PR DESCRIPTION
- Add FreeRTOS test report for TTGO T-Display-GD32
- Add RT-Thread test report for TTGO T-Display-GD32
- Add ThreadX test report for TTGO T-Display-GD32
- Add μC/OS-II test report for TTGO T-Display-GD32
- Add μC/OS-II test report for Sipeed Longan Nano

\* extensive testing shows that these two boards could be considered identical compilation-wise.