### PR TITLE
LicheeRV & Duo & Duo256m & VisionFive2/nixos: fix typo

### DIFF
--- a/D1_LicheeRV/NixOS/README.md
+++ b/D1_LicheeRV/NixOS/README.md
@@ -1,5 +1,5 @@
 ---
-sys: NixOS
+sys: nixos
 sys_ver: null
 sys_var: null
 
@@ -7,7 +7,7 @@ status: basic
 last_update: 2024-12-20
 ---
 
-# Nixos LicheeRV Test Report
+# NixOS LicheeRV Test Report
 
 ## Test Environment
 

--- a/Duo/NixOS/README.md
+++ b/Duo/NixOS/README.md
@@ -1,5 +1,5 @@
 ---
-sys: NixOS
+sys: nixos
 sys_ver: null
 sys_var: null
 

--- a/Duo256m/NixOS/README.md
+++ b/Duo256m/NixOS/README.md
@@ -1,5 +1,5 @@
 ---
-sys: NixOS
+sys: nixos
 sys_ver: null
 sys_var: null
 

--- a/VisionFive2/NixOS/README.md
+++ b/VisionFive2/NixOS/README.md
@@ -1,5 +1,5 @@
 ---
-sys: NixOS
+sys: nixos
 sys_ver: null
 sys_var: null
 


### PR DESCRIPTION
`nixos` was written as `NixOS` in some reports, which makes some NixOS reports missing from the generated tables