### PR TITLE
Fix: broken Zephyr link

### DIFF
--- a/Longan_Nano/README.md
+++ b/Longan_Nano/README.md
@@ -16,7 +16,7 @@ cpu_core: Nuclei Bumblebee
         - https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_longan_nano.html
 - Zephyr
     - Source Code: https://github.com/zephyrproject-rtos/zephyr/tree/main
-    - Reference Installation Document: https://docs.zephyrproject.org/latest/develop/getting_started/index.html
+    - Reference Installation Document: https://docs.zephyrproject.org/latest/boards/sipeed/longan_nano/doc/index.html
 
 ### Hardware Information
 

--- a/Longan_Nano/README_zh.md
+++ b/Longan_Nano/README_zh.md
@@ -10,7 +10,7 @@
         - https://doc.nucleisys.com/nuclei_sdk/design/board/gd32vf103c_longan_nano.html
 - Zephyr
     - 源码链接：https://github.com/zephyrproject-rtos/zephyr/tree/main
-    - 参考文档：https://docs.zephyrproject.org/latest/develop/getting_started/index.html
+    - 参考文档：https://docs.zephyrproject.org/latest/boards/sipeed/longan_nano/doc/index.html
 
 ### 硬件开发板信息
 

--- a/Longan_Nano/Zephyr/README.md
+++ b/Longan_Nano/Zephyr/README.md
@@ -1,6 +1,6 @@
 ---
 sys: zephyr
-sys_ver: null
+sys_ver: v3.6.0
 sys_var: null
 
 status: basic
@@ -14,7 +14,7 @@ last_update: 2024-06-21
 ### Operating System Information
 
 - Source Code: https://github.com/zephyrproject-rtos/zephyr/tree/main
-- Reference Installation Document: https://docs.zephyrproject.org/latest/develop/getting_started/index.html
+- Reference Installation Document: https://docs.zephyrproject.org/latest/boards/sipeed/longan_nano/doc/index.html
 
 ### Hardware Information
 

--- a/Longan_Nano/Zephyr/README_zh.md
+++ b/Longan_Nano/Zephyr/README_zh.md
@@ -5,7 +5,7 @@
 ### 操作系统信息
 
 - 源码链接：https://github.com/zephyrproject-rtos/zephyr/tree/main
-- 参考文档：https://docs.zephyrproject.org/latest/develop/getting_started/index.html
+- 参考文档：https://docs.zephyrproject.org/latest/boards/sipeed/longan_nano/doc/index.html
 
 ### 硬件信息
 

--- a/Unmatched/README.md
+++ b/Unmatched/README.md
@@ -29,7 +29,7 @@ cpu_core: SiFive U74 + SiFive S7
     - Download link: https://mirrors.tuna.tsinghua.edu.cn/OpenBSD/7.4/riscv64/install74.img
     - Reference Installation Document: https://ftp.openbsd.org/pub/OpenBSD/snapshots/riscv64/INSTALL.riscv64
 - Zephyr
-    - Reference Installation Document: https://docs.zephyrproject.org/latest/boards/riscv/index.html
+    - Reference Installation Document: https://docs.zephyrproject.org/latest/boards/sifive/hifive_unmatched/doc/index.html
 - OpenWrt 23.05.2
     - Download link (Firmware Selector): https://firmware-selector.openwrt.org/?version=23.05.2&target=sifiveu%2Fgeneric&id=sifive_unmatched
     - Reference Installation Document: https://openwrt.org/docs/techref/hardware/soc/soc.sifive

--- a/Unmatched/README_zh.md
+++ b/Unmatched/README_zh.md
@@ -23,7 +23,7 @@
     - 下载链接：https://mirrors.tuna.tsinghua.edu.cn/OpenBSD/7.4/riscv64/install74.img
     - 参考安装文档：https://ftp.openbsd.org/pub/OpenBSD/snapshots/riscv64/INSTALL.riscv64
 - Zephyr
-    - 参考安装文档：https://docs.zephyrproject.org/latest/boards/riscv/index.html
+    - 参考安装文档：https://docs.zephyrproject.org/latest/boards/sifive/hifive_unmatched/doc/index.html
 - OpenWrt 23.05.2
     - 下载链接（Firmware Selector）：https://firmware-selector.openwrt.org/?version=23.05.2&target=sifiveu%2Fgeneric&id=sifive_unmatched
     - 参考安装文档：https://openwrt.org/docs/techref/hardware/soc/soc.sifive

--- a/Unmatched/Zephyr/README.md
+++ b/Unmatched/Zephyr/README.md
@@ -1,6 +1,6 @@
 ---
 sys: zephyr
-sys_ver: null
+sys_ver: v3.6.0
 sys_var: null
 
 status: basic
@@ -15,7 +15,7 @@ last_update: 2024-06-21
 
 - Host: Arch Linux
 - Board: Zephyr RTOS
-- Reference Installation Document: https://docs.zephyrproject.org/latest/boards/riscv/index.html
+- Reference Installation Document: https://docs.zephyrproject.org/latest/boards/sifive/hifive_unmatched/doc/index.html
 
 ### Hardware Information
 

--- a/Unmatched/Zephyr/README_zh.md
+++ b/Unmatched/Zephyr/README_zh.md
@@ -6,7 +6,7 @@
 
 - Host: Arch Linux
 - Board: Zephyr RTOS
-- 参考安装文档：https://docs.zephyrproject.org/latest/boards/riscv/index.html
+- 参考安装文档：https://docs.zephyrproject.org/latest/boards/sifive/hifive_unmatched/doc/index.html
 
 ### 硬件信息
 


### PR DESCRIPTION
[this URL](https://docs.zephyrproject.org/latest/boards/riscv/index.html) in Unmatched test report is unaccessble now