### PR TITLE
Add eweOS test reports for Mars

### DIFF
--- a/Mars/README.md
+++ b/Mars/README.md
@@ -24,6 +24,10 @@ cpu_core: SiFive U74 + SiFive S7 + SiFive E24
   - Reference Installation Document:
     1. <https://milkv.io/zh/docs/mars/getting-started/boot>
     2. <https://deepin-community.github.io/sig-deepin-ports/docs/install/riscv/jh7110>
+- eweOS
+  - Dowload Link：<https://github.com/panglars/eweos-vf2-mainline>
+  - Reference Installation Document: <https://github.com/panglars/eweos-vf2-mainline/blob/main/README.md>
+  - eweOS Website: <https://os.ewe.moe/>
 
 ### Hardware Information
 
@@ -38,9 +42,11 @@ cpu_core: SiFive U74 + SiFive S7 + SiFive E24
 | Ubuntu Image Boot      | N/A          | [CFT][Ubuntu]                                |
 | Ubuntu LTS Image Boot  | N/A          | [Successful][Ubuntu LTS]                            |
 | Deepin Image Boot      | N/A          | [Successful][Deepin]                                |
+| eweOS Image Boot       | N/A          | [Successful][eweOS]                                |
 
 [Debian]: ./Debian/README.md
 [BuildRoot]: ./BuildRoot/README.md
 [Ubuntu]: ./Ubuntu/README.md
 [Ubuntu LTS]: ./Ubuntu/README_LTS.md
 [Deepin]: ./Deepin/README.md
+[eweOS]: ./eweOS/README.md

--- a/Mars/README_zh.md
+++ b/Mars/README_zh.md
@@ -17,6 +17,10 @@
   - 参考安装文档：
     1. <https://milkv.io/zh/docs/mars/getting-started/boot>
     2. <https://deepin-community.github.io/sig-deepin-ports/docs/install/riscv/jh7110>
+- eweOS
+  - 下载链接：<https://github.com/panglars/eweos-vf2-mainline>
+  - 参考安装文档：<https://github.com/panglars/eweos-vf2-mainline/blob/main/README.md>
+  - eweOS官网：<https://os.ewe.moe/>
 
 ### 硬件开发板信息
 
@@ -31,9 +35,11 @@
 | Ubuntu 镜像启动      | N/A      | [CFT][Ubuntu]                     |
 | Ubuntu LTS 镜像启动  | N/A      | [成功][Ubuntu LTS]                 |
 | Deepin 镜像启动      | N/A      | [成功][Deepin]                     |
+| eweOS 镜像启动       | N/A      | [成功][eweOS]                     |
 
 [Debian]: ./Debian/README_zh.md
 [BuildRoot]: ./BuildRoot/README_zh.md
 [Ubuntu]: ./Ubuntu/README_zh.md
 [Ubuntu LTS]: ./Ubuntu/README_LTS_zh.md
 [Deepin]: ./Deepin/README_zh.md
+[eweOS]: ./eweOS/README_zh.md

--- a/Mars/eweOS/README.md
+++ b/Mars/eweOS/README.md
@@ -1,0 +1,148 @@
+---
+sys: eweOS
+sys_ver: 6.13.8
+sys_var: null
+
+status: basic
+last_update: 2025-03-28
+---
+
+# eweOS Milk-V Mars Test Report
+
+## Test Environment
+
+### Operating System Information
+
+- System Version: eweOS
+- Download Link: <https://github.com/panglars/eweos-vf2-mainline>
+- Reference Installation Document: <https://github.com/panglars/eweos-vf2-mainline/blob/main/README.md>
+- eweOS Website: <https://os.ewe.moe/>
+
+### Hardware Information
+
+- Milk-V Mars (V1.21)
+- A USB Power Adapter
+- A USB-A to C or C to C Cable
+- A microSD Card
+- A USB to UART Debugger (e.g., CH340, CH341, FT2232, etc.)
+
+## Installation Steps
+
+### Build Image
+
+- Change `CROSS_COMPILE` in `build.sh` according to your local RISC-V toolchain prefix
+
+- Change eweOS mirror link `${WGET} https://os-repo-lu.ewe.moe/eweos-images/eweos-riscv64-tarball.tar.xz` in `build.sh` to `${WGET} https://os-repo-auto.ewe.moe/eweos-images/eweos-riscv64-tarball.tar.xz` (Source of link: <https://os-wiki.ewe.moe/guides/qemu-boot-isoimage>)
+
+``` bash
+chmod +x ./build.sh
+sudo ./build.sh
+```
+
+the resulting image is `ewe-vf2.img`.
+
+### Flashing Image to microSD Card
+
+```bash
+sudo dd if=ewe-vf2.img of=/dev/<your-device> bs=1M status=progress
+```
+
+> [!Note]
+> The build process will mount the image and perform the `chroot` operation, and the network will download the software package, so the image can only be successfully built automatically on a RISC-V HOST machine with a network connection.
+
+### Logging into the System
+
+Logging into the system via the serial port.
+
+Default username: `ewe`
+
+Default password: `ewe`
+
+Root password: `ewe`
+
+## Expected Results
+
+The system should boot normally and allow login via the onboard serial port.
+
+## Actual Results
+
+The system booted successfully and login via the onboard serial port was also successful.
+
+### Boot Log
+
+```log
+eweOS 6.13.8 (/dev/ttyS0)
+
+
+eweos-diskimage login: ewe
+Password:
+
+Welcome to eweOS!
+
+ * Mainpage: https://os.ewe.moe
+ * Wiki:     https://os-wiki.ewe.moe
+ * Packages: https://os.ewe.moe/pkglist
+
+[ewe@eweos-diskimage ~]$ cat /etc/os-release
+NAME="eweOS"
+ID=ewe
+PRETTY_NAME="eweOS"
+BUILD_ID=rolling
+ANSI_COLOR="0;36"
+HOME_URL="https://os.ewe.moe"
+SUPPORT_URL="https://os.ewe.moe"
+BUG_REPORT_URL="https://os.ewe.moe"
+LOGO=eweos-logo
+[ewe@eweos-diskimage ~]$ uname -a
+Linux eweos-diskimage 6.13.8 #1 SMP Wed Mar 26 17:04:22 UTC 2025 riscv64 GNU/Linux
+[ewe@eweos-diskimage ~]$ cat /proc/cpuinfo
+processor       : 0
+hart            : 1
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+
+processor       : 1
+hart            : 2
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+
+processor       : 2
+hart            : 3
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+
+processor       : 3
+hart            : 4
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+```
+
+## Test Criteria
+
+Successful: The actual result matches the expected result.
+
+Failed: The actual result does not match the expected result.
+
+## Test Conclusion
+
+Test Successful.

--- a/Mars/eweOS/README_zh.md
+++ b/Mars/eweOS/README_zh.md
@@ -1,0 +1,139 @@
+# eweOS Milk-V Mars 测试报告
+
+## 测试环境
+
+### 操作系统信息
+
+- 系统版本：eweOS
+- 下载链接：<https://github.com/panglars/eweos-vf2-mainline>
+- 参考安装文档：<https://github.com/panglars/eweos-vf2-mainline/blob/main/README.md>
+- eweOS官网: <https://os.ewe.moe/>
+
+### 硬件信息
+
+- Milk-V Mars (V1.21)
+- USB 电源适配器一个
+- USB-A to C 或 C to C 线缆一条
+- microSD 卡一张
+- USB to UART 调试器一个（如：CH340, CH341, FT2232 等）
+
+## 安装步骤
+
+### 构建镜像
+
+- 根据本地RISC-V工具链前缀更改 `build.sh` 中的 `CROSS_COMPILE`
+
+- 修改 `build.sh` 中eweOS的镜像链接 `${WGET} https://os-repo-lu.ewe.moe/eweos-images/eweos-riscv64-tarball.tar.xz`为 `${WGET} https://os-repo-auto.ewe.moe/eweos-images/eweos-riscv64-tarball.tar.xz` (链接出处：<https://os-wiki.ewe.moe/guides/qemu-boot-isoimage>)
+
+``` bash
+chmod +x ./build.sh
+sudo ./build.sh
+```
+
+构建出的镜像为 `ewe-vf2.img`
+
+> [!Note]
+> 构建的流程中会挂载镜像并执行 `chroot` 操作，且会联网下载软件包，故只有在一台能联网的RISC-V架构的HOST机器上才能成功自动构建镜像。
+
+### 刷写镜像到 microSD 卡
+
+```bash
+sudo dd if=ewe-vf2.img of=/dev/<your-device> bs=1M status=progress
+```
+
+### 登录系统
+
+通过串口登录系统。
+
+默认用户名：`ewe`
+
+默认密码：`ewe`
+
+Root 帐户密码:`ewe`
+
+## 预期结果
+
+系统正常启动，能够通过板载串口登录。
+
+## 实际结果
+
+系统正常启动，成功通过板载串口登录。
+
+### 启动信息
+
+```log
+eweOS 6.13.8 (/dev/ttyS0)
+
+
+eweos-diskimage login: ewe
+Password:
+
+Welcome to eweOS!
+
+ * Mainpage: https://os.ewe.moe
+ * Wiki:     https://os-wiki.ewe.moe
+ * Packages: https://os.ewe.moe/pkglist
+
+[ewe@eweos-diskimage ~]$ cat /etc/os-release
+NAME="eweOS"
+ID=ewe
+PRETTY_NAME="eweOS"
+BUILD_ID=rolling
+ANSI_COLOR="0;36"
+HOME_URL="https://os.ewe.moe"
+SUPPORT_URL="https://os.ewe.moe"
+BUG_REPORT_URL="https://os.ewe.moe"
+LOGO=eweos-logo
+[ewe@eweos-diskimage ~]$ uname -a
+Linux eweos-diskimage 6.13.8 #1 SMP Wed Mar 26 17:04:22 UTC 2025 riscv64 GNU/Linux
+[ewe@eweos-diskimage ~]$ cat /proc/cpuinfo
+processor       : 0
+hart            : 1
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+
+processor       : 1
+hart            : 2
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+
+processor       : 2
+hart            : 3
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+
+processor       : 3
+hart            : 4
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+```
+
+## 测试判定标准
+
+测试成功：实际结果与预期结果相符。
+
+测试失败：实际结果与预期结果不符。
+
+## 测试结论
+
+测试成功。


### PR DESCRIPTION
# Welcome to Pull Request

Thank you for your contribution! Please refer to the [contributing guidelines](../CONTRIBUTING.md) for more details.

## If you are working on the support-matrix report

We appreciate your effort in improving the support matrix. To generate the SVG image locally, you can use:

```sh
python assets/generate_svgimage.py -p . -o assets/output --html https://${{ github.repository_owner }}.github.io/support-matrix
```

For internationalization (i18n) SVG generation  test, simply add the `-l zh` option.

If you're creating a new report, please refer to our templates:
- [Board report template](../report-template/[board-name]/README.md)
- [OS report template](../report-template/[board-name]/[os-name]/README.md)

### Checklist
- [ ] SVG table generation passes successfully
- [ ] Appropriate changes to documentation are included in the PR
- [ ] i18n for documentation (optional)

## If you are working on the assets toolchain

Fixes #<issue_number_goes_here>

> We recommend opening an issue for discussion before making significant changes.

### Checklist
- [ ] Changes to workflow/codes are fully tested
- [ ] Appropriate changes to documentation are included in the PR
- [ ] This fixes an issue
- [ ] New feature added
