### PR TITLE
CONTRIBUTING: change/add some definitions in metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ vendor: _     # Vendor identifier (lowercase letters + underscores)
 product: _    # Full product name
 cpu: _        # Processor model
 cpu_core: _   # CPU core architecture
+board_variant: [] # Board variant (optional, like 8g/16g version)
 ---
 ```
 
@@ -72,7 +73,7 @@ Note that some boards currently lack the vendor field, which can be left empty. 
 ```yaml
 # /Board/OS/README.md
 sys: armbian          # System identifier (refer to assets/metadata.yml)
-sys_ver: 24.05        # System version (preferably using semantic versioning)
+sys_ver: "24.05"        # System version (Should be the same as the one of the image, shouldn't add any extra part to match other format like semantic versioning. Prepend `v` is optional. *Notice: something like `24.05` would be seen as a number, so please add quotation if necessary*)
 sys_var: minimal      # Variant identifier (optional)
 status: basic         # Support status (none/wip/cft/cfh/cfi/partial/basic/good)
 last_updated: 2024-03-01  # Last update date
@@ -86,11 +87,9 @@ The LTS identifier exists in some sys_var fields as a variant for historical rea
 Ideally, Ubuntu 24.04.1 in NeZha-D1s/Ubuntu/README_LTS.md should be written as:
 
 ```yaml
-sys_ver: 24.04-LTS-SP1        # System version (preferably using semantic versioning)
+sys_ver: 24.04-LTS-SP1        # System version (Should be the same as the one of the image, shouldn't add any extra part to match other format like semantic versioning. Prepend `v` is optional.)
 sys_var: LTS                  # Variant identifier (optional)
 ```
-
-It's best to ensure that sys_ver can be correctly matched by `(v)?(\d+)\.(\d+)(\.(\d+))?((-(?:(?!SP)\w+))*)(-SP(\d+))?((-(\w+))*)?((\+(\w+))*)?`. Otherwise, you might have to rewrite some CI scripts.
 
 If there are any parts that are still unclear, please contact @wychlw.
 

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -64,6 +64,7 @@ vendor: _     # 厂商标识（小写字母+下划线）
 product: _    # 产品全称
 cpu: _        # 处理器型号
 cpu_core: _   # CPU 核心架构
+board_variant: [] # 开发板变体（可选，如 8g/16g 版本）
 ---
 ```
 
@@ -72,7 +73,7 @@ vendor 字段目前有部分板子暂缺，可以留空。如需填写，需要�
 ```yaml
 # /开发板/发行版/README.md
 sys: armbian          # 系统标识（参考 assets/metadata.yml）
-sys_ver: 24.05        # 系统版本（尽量采用语义化版本号）
+sys_ver: "24.05"        # 系统版本（应当和镜像的版本相同，不要强行加入其余部分来满足如语义化版本号等格式。前导 `v` 可省略。 *注意：如 `24.05` 会被视为一个数字，必要时请添加引号。*）
 sys_var: minimal      # 变体标识（可选）
 status: basic         # 支持状态（none/wip/cft/cfh/partial/basic/good）
 last_updated: 2024-03-01  # 报告最后更新时间
@@ -86,11 +87,9 @@ LTS 标识因历史原因存在于部分 sys_var 中作为变体，但目前通�
 理想情况下 NeZha-D1s/Ubuntu/README_LTS.md 中 Ubuntu 24.04.1 应当写作：
 
 ```yaml
-sys_ver: 24.04-LTS-SP1        # 系统版本（尽量采用语义化版本号）
+sys_ver: 24.04-LTS-SP1        # 系统版本（应当和镜像的版本相同，不要强行加入其余部分来满足如语义化版本号等格式。前导 `v` 可省略）
 sys_var: LTS                  # 变体标识（可选）
 ```
-
-最好保证 sys_ver 可被 `(v)?(\d+)\.(\d+)(\.(\d+))?((-(?:(?!SP)\w+))*)(-SP(\d+))?((-(\w+))*)?((\+(\w+))*)?` 正确匹配。否则你可能不得不改写一些 CI 脚本。
 
 如还有不清楚的部分，可以联系 @wychlw。
 

--- a/report-template/README.md
+++ b/report-template/README.md
@@ -1,11 +1,11 @@
-# 报告模板概述
+# Report Template Overview
 
-这里提供了针对不同开发板和操作系统的报告模板，旨在帮助贡献者记录和分享他们的测试结果。每个模板都包含了必要的结构和格式，以确保信息的清晰和一致性。
+This section provides report templates for different development boards and operating systems, designed to help contributors document and share their test results. Each template includes the necessary structure and format to ensure clarity and consistency of information.
 
-## 使用说明
+## Usage Guidelines
 
-1. **针对开发板的报告模板**：位于 `report-template/[board-name]/README.md`，用于记录特定开发板的基本信息、硬件规格、支持的操作系统及测试结果。
+1. **Report Template for Development Boards**: Located at `report-template/[board-name]/README.md`, used to record basic information, hardware specifications, supported operating systems, and test results for specific development boards.
 
-2. **针对操作系统的测试报告模板**：位于 `report-template/[board-name]/[os-name]/README.md`，用于记录特定操作系统的测试环境、安装步骤、预期结果、实际结果及测试结论。
+2. **Test Report Template for Operating Systems**: Located at `report-template/[board-name]/[os-name]/README.md`, used to record the testing environment, installation steps, expected results, actual results, and test conclusions for specific operating systems.
 
-请根据具体的开发板和操作系统，填充和修改相应的模板内容。
+Please fill in and modify the corresponding template content according to the specific development board and operating system.

--- a/report-template/README_zh.md
+++ b/report-template/README_zh.md
@@ -1,11 +1,11 @@
-# Report Template Overview
+# 报告模板概述
 
-This section provides report templates for different development boards and operating systems, designed to help contributors document and share their test results. Each template includes the necessary structure and format to ensure clarity and consistency of information.
+这里提供了针对不同开发板和操作系统的报告模板，旨在帮助贡献者记录和分享他们的测试结果。每个模板都包含了必要的结构和格式，以确保信息的清晰和一致性。
 
-## Usage Guidelines
+## 使用说明
 
-1. **Report Template for Development Boards**: Located at `report-template/[board-name]/README.md`, used to record basic information, hardware specifications, supported operating systems, and test results for specific development boards.
+1. **针对开发板的报告模板**：位于 `report-template/[board-name]/README.md`，用于记录特定开发板的基本信息、硬件规格、支持的操作系统及测试结果。
 
-2. **Test Report Template for Operating Systems**: Located at `report-template/[board-name]/[os-name]/README.md`, used to record the testing environment, installation steps, expected results, actual results, and test conclusions for specific operating systems.
+2. **针对操作系统的测试报告模板**：位于 `report-template/[board-name]/[os-name]/README.md`，用于记录特定操作系统的测试环境、安装步骤、预期结果、实际结果及测试结论。
 
-Please fill in and modify the corresponding template content according to the specific development board and operating system.
+请根据具体的开发板和操作系统，填充和修改相应的模板内容。

--- a/report-template/[board-name]/README.md
+++ b/report-template/[board-name]/README.md
@@ -3,6 +3,8 @@ product: [Development Board Name]
 vendor: [Vendor Name]
 cpu: [CPU Model]
 cpu_core: [CPU Core Architecture]
+
+board_variant: [Board Variant] # e.g., 8g/16g version
 ---
 
 # [Development Board Name]

--- a/report-template/[board-name]/[os-name]/README.md
+++ b/report-template/[board-name]/[os-name]/README.md
@@ -5,6 +5,9 @@ sys_var: [Variant Identifier]
 
 status: [Support Status]
 last_update: [Last Update Date]
+
+# Below is optional, please fill in if necessary
+skip_sync: false/*true* # If true, skip the sync process
 ---
 
 # [Operating System Name]


### PR DESCRIPTION
- Fix: report-template README.md wrong lang
- sys_ver: As ruyi now require upstream version, shouldn't manually map the version now
- add definition for `board_variant` and `skip_sync`
