### PR TITLE
Add ram information for the boards

### DIFF
--- a/100ASK/README.md
+++ b/100ASK/README.md
@@ -2,6 +2,7 @@
 product: 100ASK-V853-PRO
 cpu: V853
 cpu_core: XuanTie E907 + ARM Cortex-A7
+ram: 512MB/1G
 ---
 
 # 100ASK-V853-PRO

--- a/BPI-F3/README.md
+++ b/BPI-F3/README.md
@@ -3,6 +3,7 @@ vendor: "bpi_f3"
 product: BananaPi BPI-F3
 cpu: Key Stone K1
 cpu_core: SpacemiT X60
+ram: 2G/4G/8G/16G
 ---
 
 # Banana Pi BPI-F3

--- a/BeagleV-Ahead/README.md
+++ b/BeagleV-Ahead/README.md
@@ -2,6 +2,7 @@
 product: BeagleV-Ahead
 cpu: TH1520
 cpu_core: XuanTie C910 + XuanTie C906 + XuanTie E902
+ram: 4G
 ---
 
 # BeagleV-Ahead

--- a/BeagleV-Fire/README.md
+++ b/BeagleV-Fire/README.md
@@ -2,6 +2,7 @@
 product: BeagleV-Fire
 cpu: MPFS025T
 cpu_core: SiFive U54 + SiFive E51
+ram: 2G
 ---
 
 # BeagleV-Fire

--- a/Bit-Brick_K1/README.md
+++ b/Bit-Brick_K1/README.md
@@ -2,6 +2,7 @@
 product: BIT-BRICK K1
 cpu: Key Stone K1
 cpu_core: SpacemiT X60
+ram: 4G/8G
 ---
 
 # BIT-BRICK K1

--- a/CH32V103/README.md
+++ b/CH32V103/README.md
@@ -2,6 +2,7 @@
 product: CH32V103-EVT
 cpu: CH32V103
 cpu_core: QingKe V3A
+ram: 20KB(SRAM) + 64KB(Flash)
 ---
 
 # CH32V103C

--- a/CH32V103/README.md
+++ b/CH32V103/README.md
@@ -2,7 +2,7 @@
 product: CH32V103-EVT
 cpu: CH32V103
 cpu_core: QingKe V3A
-ram: 20KB(SRAM) + 64KB(Flash)
+ram: 20KB(SRAM)
 ---
 
 # CH32V103C

--- a/CH32V203/README.md
+++ b/CH32V203/README.md
@@ -2,6 +2,7 @@
 product: CH32V203-EVT
 cpu: CH32V203
 cpu_core: QingKe V4B
+ram: 64KB(SRAM) + 256KB(Flash)
 ---
 
 

--- a/CH32V203/README.md
+++ b/CH32V203/README.md
@@ -2,7 +2,7 @@
 product: CH32V203-EVT
 cpu: CH32V203
 cpu_core: QingKe V4B
-ram: 64KB(SRAM) + 256KB(Flash)
+ram: 64KB(SRAM)
 ---
 
 

--- a/CH32V208/README.md
+++ b/CH32V208/README.md
@@ -2,7 +2,7 @@
 product: CH32V208-EVT
 cpu: CH32V208
 cpu_core: QingKe V4C
-ram: 64KB(SRAM) + 128KB(Flash)
+ram: 64KB(SRAM)
 ---
 
 # CH32V208

--- a/CH32V208/README.md
+++ b/CH32V208/README.md
@@ -2,6 +2,7 @@
 product: CH32V208-EVT
 cpu: CH32V208
 cpu_core: QingKe V4C
+ram: 64KB(SRAM) + 128KB(Flash)
 ---
 
 # CH32V208
@@ -31,4 +32,3 @@ cpu_core: QingKe V4C
 [FreeRTOS]: ./FreeRTOS/README.md
 [RTThread]: ./RT-Thread/README.md
 [LiteOS]: ./LiteOS/README.md
-

--- a/CH32V303/README.md
+++ b/CH32V303/README.md
@@ -2,7 +2,7 @@
 product: CH32V303-EVT
 cpu: CH32V303
 cpu_core: QingKe V4F
-ram: 64KB(SRAM) + 256KB(Flash)
+ram: 64KB(SRAM)
 ---
 
 

--- a/CH32V303/README.md
+++ b/CH32V303/README.md
@@ -2,6 +2,7 @@
 product: CH32V303-EVT
 cpu: CH32V303
 cpu_core: QingKe V4F
+ram: 64KB(SRAM) + 256KB(Flash)
 ---
 
 

--- a/CH32V305/README.md
+++ b/CH32V305/README.md
@@ -2,7 +2,7 @@
 product: CH32V305-EVT
 cpu: CH32V305
 cpu_core: QingKe V4F
-ram: 32KB(SRAM) + 128KB(Flash)
+ram: 32KB(SRAM)
 ---
 
 

--- a/CH32V305/README.md
+++ b/CH32V305/README.md
@@ -2,6 +2,7 @@
 product: CH32V305-EVT
 cpu: CH32V305
 cpu_core: QingKe V4F
+ram: 32KB(SRAM) + 128KB(Flash)
 ---
 
 

--- a/CH32V307/README.md
+++ b/CH32V307/README.md
@@ -2,6 +2,7 @@
 product: CH32V307-EVT
 cpu: CH32V307
 cpu_core: QingKe V4F
+ram: 64KB(SRAM) + 256KB(Flash)
 ---
 
 

--- a/CH32V307/README.md
+++ b/CH32V307/README.md
@@ -2,7 +2,7 @@
 product: CH32V307-EVT
 cpu: CH32V307
 cpu_core: QingKe V4F
-ram: 64KB(SRAM) + 256KB(Flash)
+ram: 64KB(SRAM)
 ---
 
 

--- a/CH573F/README.md
+++ b/CH573F/README.md
@@ -2,6 +2,7 @@
 product: CH573F-EVT
 cpu: CH573F
 cpu_core: QingKe V3A
+ram: 18KB(SRAM) + 512KB(Flash)
 ---
 
 
@@ -31,4 +32,3 @@ cpu_core: QingKe V3A
 
 [FreeRTOS]: ./FreeRTOS/README.md
 [RTThread]: ./RT-Thread/README.md
-

--- a/CH573F/README.md
+++ b/CH573F/README.md
@@ -2,7 +2,7 @@
 product: CH573F-EVT
 cpu: CH573F
 cpu_core: QingKe V3A
-ram: 18KB(SRAM) + 512KB(Flash)
+ram: 18KB(SRAM)
 ---
 
 

--- a/CH582F/README.md
+++ b/CH582F/README.md
@@ -2,7 +2,7 @@
 product: CH582F-EVT
 cpu: CH582F
 cpu_core: QingKe V4A
-ram: 32KB(SRAM) + 512KB(Flash)
+ram: 32KB(SRAM)
 ---
 
 

--- a/CH582F/README.md
+++ b/CH582F/README.md
@@ -2,6 +2,7 @@
 product: CH582F-EVT
 cpu: CH582F
 cpu_core: QingKe V4A
+ram: 32KB(SRAM) + 512KB(Flash)
 ---
 
 
@@ -29,4 +30,3 @@ cpu_core: QingKe V4A
 
 [FreeRTOS]: ./FreeRTOS/README.md
 [RTThread]: ./RT-Thread/README.md
-

--- a/CH592X/README.md
+++ b/CH592X/README.md
@@ -2,6 +2,7 @@
 product: CH592X-EVT
 cpu: CH592X
 cpu_core: QingKe V4C
+ram: 26KB(SRAM) + 512KB(Flash)
 ---
 
 

--- a/CH592X/README.md
+++ b/CH592X/README.md
@@ -2,7 +2,7 @@
 product: CH592X-EVT
 cpu: CH592X
 cpu_core: QingKe V4C
-ram: 26KB(SRAM) + 512KB(Flash)
+ram: 26KB(SRAM)
 ---
 
 

--- a/CM32M433R/README.md
+++ b/CM32M433R/README.md
@@ -2,6 +2,7 @@
 product: CM32M433R-START
 cpu: CM32M433R
 cpu_core: Nuclei N308
+ram: 144KB(SRAM) + 512KB(Flash)
 ---
 
 # CM32M433R-START

--- a/CM32M433R/README.md
+++ b/CM32M433R/README.md
@@ -2,7 +2,7 @@
 product: CM32M433R-START
 cpu: CM32M433R
 cpu_core: Nuclei N308
-ram: 144KB(SRAM) + 512KB(Flash)
+ram: 144KB(SRAM)
 ---
 
 # CM32M433R-START

--- a/DDR200T/README.md
+++ b/DDR200T/README.md
@@ -2,6 +2,7 @@
 product: Nuclei DDR200T
 cpu: GD32VF103
 cpu_core: Nuclei Bumblebee
+ram: 32KB(SRAM) + 128KB(Flash)
 ---
 
 # Nuclei DDR200T

--- a/DDR200T/README.md
+++ b/DDR200T/README.md
@@ -2,7 +2,7 @@
 product: Nuclei DDR200T
 cpu: GD32VF103
 cpu_core: Nuclei Bumblebee
-ram: 32KB(SRAM) + 128KB(Flash)
+ram: 32KB(SRAM)
 ---
 
 # Nuclei DDR200T

--- a/DongShanPI-D1s/README.md
+++ b/DongShanPI-D1s/README.md
@@ -2,6 +2,7 @@
 product: DongShanPI D1s
 cpu: D1s
 cpu_core: XuanTie C906
+ram: 64MB
 ---
 
 # DongshanPI-D1s

--- a/DongshanPI-STU/README.md
+++ b/DongshanPI-STU/README.md
@@ -2,6 +2,7 @@
 product: DongshanPI-Nezha STU
 cpu: D1 (D1-H)
 cpu_core: XuanTie C906
+ram: 256MB
 ---
 
 # DongshanPI-Nezha STU

--- a/Duo/README.md
+++ b/Duo/README.md
@@ -3,6 +3,7 @@ vendor: milkv_duo
 product: Milk-V Duo (64M)
 cpu: CV1800B
 cpu_core: XuanTie C906
+ram: 64MB
 ---
 
 # Milk-V Duo

--- a/Duo256m/README.md
+++ b/Duo256m/README.md
@@ -3,6 +3,7 @@ vendor: milkv_duo256m
 product: Milk-V Duo (256M)
 cpu: SG2002
 cpu_core: XuanTie C906 + ARM Cortex-A53
+ram: 256MB
 ---
 
 # Milk-V Duo 256M

--- a/Duo_S/README.md
+++ b/Duo_S/README.md
@@ -3,6 +3,7 @@ vendor: milkv_duos
 product: Milk-V Duo S
 cpu: SG2000
 cpu_core: XuanTie C906 + ARM Cortex-A53
+ram: 256MB
 ---
 
 # Milk-V Duo S

--- a/Huashan_Pi/README.md
+++ b/Huashan_Pi/README.md
@@ -2,6 +2,7 @@
 product: Huashan Pi
 cpu: CV1812H
 cpu_core: XuanTie C906
+ram: 1G/2G/4G
 ---
 
 # Huashan Pi

--- a/Icicle/README.md
+++ b/Icicle/README.md
@@ -2,6 +2,7 @@
 product: PolarFire FPGA SoC Icicle Kit
 cpu: MPFS250T
 cpu_core: SiFive U54 + SiFive E51
+ram: 2G
 ---
 
 # Microchip Polarfire SoC FPGA Icicle Kit
@@ -63,4 +64,3 @@ cpu_core: SiFive U54 + SiFive E51
 [FreeRTOS]: ./FreeRTOS/README.md
 [Zephyr]: ./Zephyr/README.md
 [NuttX]: ./NuttX/README.md
-

--- a/Jupiter/README.md
+++ b/Jupiter/README.md
@@ -2,6 +2,7 @@
 product: Milk-V Jupiter
 cpu: Key Stone K1/M1
 cpu_core: SpacemiT X60
+ram: 4G/8G/16G
 ---
 
 # Milk-V Jupiter

--- a/K230/README.md
+++ b/K230/README.md
@@ -2,6 +2,7 @@
 product: CanMV K230
 cpu: K230
 cpu_core: XuanTie C908
+ram: 1G/2G
 ---
 
 # CanMV K230

--- a/K510/README.md
+++ b/K510/README.md
@@ -2,6 +2,7 @@
 product: Canaan K510-CRB-V1.2 KIT
 cpu: K510
 cpu_core: K510 (?)
+ram: 512MB
 ---
 
 # Canaan Kendryte K510

--- a/LicheeCluster4A/README.md
+++ b/LicheeCluster4A/README.md
@@ -3,6 +3,7 @@ vendor: sipeed_licheecluster4a
 product: Lichee Cluster 4A
 cpu: TH1520
 cpu_core: XuanTie C910 + XuanTie C906 + XuanTie E902
+ram: 8G/16G
 ---
 
 # Lichee Cluster 4A

--- a/LicheeConsole4A/README.md
+++ b/LicheeConsole4A/README.md
@@ -3,6 +3,7 @@ vendor: sipeed_licheeconsole4a
 product: Lichee Console 4A
 cpu: TH1520
 cpu_core: XuanTie C910 + XuanTie C906 + XuanTie E902
+ram: 8G/16G
 ---
 
 

--- a/LicheePi4A/README.md
+++ b/LicheePi4A/README.md
@@ -3,6 +3,7 @@ vendor: sipeed_licheepi4a
 product: LicheePi 4A
 cpu: TH1520
 cpu_core: XuanTie C910 + XuanTie C906 + XuanTie E902
+ram: 16G
 ---
 
 # Lichee Pi 4A

--- a/LicheePi4A_8_32/README.md
+++ b/LicheePi4A_8_32/README.md
@@ -3,6 +3,7 @@ vendor: sipeed_licheepi4a
 product: LicheePi 4A
 cpu: TH1520
 cpu_core: XuanTie C910 + XuanTie C906 + XuanTie E902
+ram: 8G
 ---
 
 # Lichee Pi 4A

--- a/LicheeRV_Dock/README.md
+++ b/LicheeRV_Dock/README.md
@@ -2,9 +2,10 @@
 product: Lichee RV Dock
 cpu: D1 (D1-H)
 cpu_core: XuanTie C906
+ram: 512MB
 ---
 
-# Lichee RV Dock 
+# Lichee RV Dock
 
 ## Test Environment
 

--- a/LicheeRV_Nano/README.md
+++ b/LicheeRV_Nano/README.md
@@ -3,6 +3,7 @@ vendor: sipeed_licheervnano
 product: LicheeRV Nano
 cpu: SG2002
 cpu_core: XuanTie C906 + ARM Cortex-A53
+ram: 2G
 ---
 
 # LicheeRV Nano

--- a/Longan_Nano/README.md
+++ b/Longan_Nano/README.md
@@ -2,6 +2,7 @@
 product: Longan Nano
 cpu: GD32VF103
 cpu_core: Nuclei Bumblebee
+ram: 32KB(SRAM) + 128KB(Flash)
 ---
 
 # Longan Nano

--- a/Longan_Nano/README.md
+++ b/Longan_Nano/README.md
@@ -2,7 +2,7 @@
 product: Longan Nano
 cpu: GD32VF103
 cpu_core: Nuclei Bumblebee
-ram: 32KB(SRAM) + 128KB(Flash)
+ram: 32KB(SRAM)
 ---
 
 # Longan Nano

--- a/M0P_Dock/README.md
+++ b/M0P_Dock/README.md
@@ -2,7 +2,7 @@
 product: Sipeed M0P Dock
 cpu: BL618
 cpu_core: XuanTie E907
-ram: 480KB(SRAM) + 4MB(Flash)
+ram: 480KB(SRAM)
 ---
 
 # Sipeed M0P Dock

--- a/M0P_Dock/README.md
+++ b/M0P_Dock/README.md
@@ -2,6 +2,7 @@
 product: Sipeed M0P Dock
 cpu: BL618
 cpu_core: XuanTie E907
+ram: 480KB(SRAM) + 4MB(Flash)
 ---
 
 # Sipeed M0P Dock

--- a/M0s/README.md
+++ b/M0s/README.md
@@ -2,7 +2,7 @@
 product: Sipeed M0s Dock
 cpu: BL616
 cpu_core: XuanTie E907
-ram: 480KB(SRAM) + 4MB(Flash)
+ram: 480KB(SRAM)
 ---
 
 # Sipeed M0s

--- a/M0s/README.md
+++ b/M0s/README.md
@@ -2,6 +2,7 @@
 product: Sipeed M0s Dock
 cpu: BL616
 cpu_core: XuanTie E907
+ram: 480KB(SRAM) + 4MB(Flash)
 ---
 
 # Sipeed M0s
@@ -15,7 +16,7 @@ cpu_core: XuanTie E907
     - Toolchain: [https://gitee.com/bouffalolab/toolchain_gcc_t-head_linux](https://gitee.com/bouffalolab/toolchain_gcc_t-head_linux)
   - Reference Installation Document: [https://github.com/sipeed/M0S_BL616_example](https://github.com/sipeed/M0S_BL616_example)
     - [https://bl-mcu-sdk.readthedocs.io/zh-cn/latest/get_started/get_started.html](https://bl-mcu-sdk.readthedocs.io/zh-cn/latest/get_started/get_started.html)
-  
+
 ### Hardware Information
 
 - Sipeed M0s Dock

--- a/M0sense/README.md
+++ b/M0sense/README.md
@@ -2,7 +2,7 @@
 product: Sipeed M0 sense
 cpu: BL702
 cpu_core: SiFive E24
-ram: 132KB(RAM) + 192(ROM) + 512KB(Flash)
+ram: 132KB
 ---
 
 # Sipeed M0sense

--- a/M0sense/README.md
+++ b/M0sense/README.md
@@ -2,6 +2,7 @@
 product: Sipeed M0 sense
 cpu: BL702
 cpu_core: SiFive E24
+ram: 132KB(RAM) + 192(ROM) + 512KB(Flash)
 ---
 
 # Sipeed M0sense

--- a/M1s/README.md
+++ b/M1s/README.md
@@ -2,6 +2,7 @@
 product: Sipeed M1s Dock
 cpu: BL808
 cpu_core: XuanTie C906 + XuanTie E907 + XuanTie E902
+ram: 768KB(SRAM) + 64MB(PSRAM)
 ---
 
 # Sipeed M1s

--- a/Maix-I_K210/README.md
+++ b/Maix-I_K210/README.md
@@ -2,6 +2,7 @@
 product: Sipeed Maix-Bit
 cpu: K210
 cpu_core: K210 (?)
+ram: 8MB(SRAM)
 ---
 
 # Sipeed Maix-I

--- a/Mars/README.md
+++ b/Mars/README.md
@@ -3,6 +3,7 @@ vendor: milkv_mars
 product: Milk-V Mars
 cpu: JH7110
 cpu_core: SiFive U74 + SiFive S7 + SiFive E24
+ram: 1G/2G/4G/8G
 ---
 
 # Milk-V Mars
@@ -32,7 +33,7 @@ cpu_core: SiFive U74 + SiFive S7 + SiFive E24
   - Download Link: <https://mirror.iscas.ac.cn/fedora-riscv/dl/StarFive/visionfive2/images/fedora-disk-gnome-workstation_starfive_vf2_f41_20241201091200.raw.gz>
   - Reference Installation Document:
     1. <https://milkv.io/zh/docs/mars/getting-started/boot>
-    2. <https://images.fedoravforce.org/Mars>  
+    2. <https://images.fedoravforce.org/Mars>
 
 ### Hardware Information
 

--- a/Megrez/README.md
+++ b/Megrez/README.md
@@ -3,6 +3,7 @@ vendor: milkv_megrez
 product: Milk-V Megrez
 cpu: EIC7700X
 cpu_core: SiFive P550
+ram: 8G/16G/32G
 ---
 
 # Milk-V Megrez
@@ -14,7 +15,7 @@ cpu_core: SiFive P550
 - RockOS
     - Project Link: https://github.com/rockos-riscv
     - Reference Installation Document
-        - https://milkv.io/zh/docs/megrez/getting-started/boot 
+        - https://milkv.io/zh/docs/megrez/getting-started/boot
         - https://rockos-riscv.github.io/rockos-docs/docs/installation
 - Fedora 41
     - Download Link: https://images.fedoravforce.org/Megrez

--- a/Meles/README.md
+++ b/Meles/README.md
@@ -3,6 +3,7 @@ product: Milk-V Meles
 vendor: milkv_meles
 cpu: TH1520
 cpu_core: XuanTie C910 + XuanTie C906 + XuanTie E902
+ram: 8G/16G
 ---
 
 # Milk-V Meles

--- a/NeZha-D1s/README.md
+++ b/NeZha-D1s/README.md
@@ -2,6 +2,7 @@
 product: D1s NeZha
 cpu: D1s
 cpu_core: XuanTie C906
+ram: 64MB
 ---
 
 # D1s NeZha

--- a/NeZha/README.md
+++ b/NeZha/README.md
@@ -2,6 +2,7 @@
 product: AWOL Nezha
 cpu: D1 (D1-H)
 cpu_core: XuanTie C906
+ram: 1G/2G
 ---
 
 # Allwinner Nezha
@@ -21,9 +22,9 @@ cpu_core: XuanTie C906
     - Nezha D1: https://d1.docs.aw-ol.com/study/study_1tina/
 - Ubuntu
   - 24.10 Download link: https://ubuntu.com/download/risc-v
-    - Mirror: [Nezha](https://mirror.tuna.tsinghua.edu.cn/ubuntu-cdimage/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64%2Bnezha.img.xz) 
+    - Mirror: [Nezha](https://mirror.tuna.tsinghua.edu.cn/ubuntu-cdimage/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64%2Bnezha.img.xz)
   - 24.04.1 LTS Download link: https://ubuntu.com/download/risc-v
-    - Mirror: [Nezha](https://mirror.tuna.tsinghua.edu.cn/ubuntu-cdimage/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64%2Bnezha.img.xz) 
+    - Mirror: [Nezha](https://mirror.tuna.tsinghua.edu.cn/ubuntu-cdimage/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64%2Bnezha.img.xz)
   - Reference Installation Document:
     - Nezha D1: https://wiki.ubuntu.com/RISC-V/Nezha%20D1
 - OpenWrt 23.05.2
@@ -37,7 +38,7 @@ cpu_core: XuanTie C906
   - Download link: https://openkoji.iscas.ac.cn/pub/dl/riscv/Allwinner/Nezha_D1/images-release/Fedora/
   - Reference Installation Document: https://fedoraproject.org/wiki/Architectures/RISC-V/Allwinner/zh-cn
 - Arch Linux
-  - Base Image: Ubuntu 24.10 Beta: [ubuntu-24.10-beta-preinstalled-server-riscv64%2Bnezha.img.xz](https://mirror.tuna.tsinghua.edu.cn/ubuntu-cdimage/releases/24.10/beta/ubuntu-24.10-beta-preinstalled-server-riscv64%2Bnezha.img.xz) 
+  - Base Image: Ubuntu 24.10 Beta: [ubuntu-24.10-beta-preinstalled-server-riscv64%2Bnezha.img.xz](https://mirror.tuna.tsinghua.edu.cn/ubuntu-cdimage/releases/24.10/beta/ubuntu-24.10-beta-preinstalled-server-riscv64%2Bnezha.img.xz)
     - Or any arbitrary image for D1
   - Rootfs: [archriscv-20220727.tar.zst](https://archriscv.felixc.at/images/archriscv-20220727.tar.zst)
   - Reference Installation Document: https://github.com/felixonmars/archriscv-packages/wiki/RV64-%E6%9D%BF%E5%AD%90%E6%9B%B4%E6%8D%A2-rootfs-%E6%8C%87%E5%8D%97

--- a/PIC64GX/README.md
+++ b/PIC64GX/README.md
@@ -2,6 +2,7 @@
 product: PIC64GX Curiosity Kit
 cpu: PIC64GX1000-V/FCS
 cpu_core: SiFive U54 + SiFive E51
+ram: 1G
 ---
 
 # Microchip PIC64GX Curiosity Kit

--- a/Pioneer/README.md
+++ b/Pioneer/README.md
@@ -3,6 +3,7 @@ product: Pioneer Box
 vendor: milkv_pioneer
 cpu: SG2042
 cpu_core: XuanTie C920
+ram: 128G
 ---
 
 

--- a/R128-EVT/README.md
+++ b/R128-EVT/README.md
@@ -2,6 +2,7 @@
 product: R128-EVT
 cpu: R128-S2
 cpu_core: XuanTie C906
+ram: 1MB(SRAM) + 16MB(PSRAM)
 ---
 
 # R128 EVT Development Kit

--- a/RV_STAR/README.md
+++ b/RV_STAR/README.md
@@ -2,6 +2,7 @@
 product: RV-STAR
 cpu: GD32VF103
 cpu_core: Nuclei Bumblebee
+ram: 32KB(SRAM) + 128KB(Flash)
 ---
 
 # RV-STAR

--- a/RV_STAR/README.md
+++ b/RV_STAR/README.md
@@ -2,7 +2,7 @@
 product: RV-STAR
 cpu: GD32VF103
 cpu_core: Nuclei Bumblebee
-ram: 32KB(SRAM) + 128KB(Flash)
+ram: 32KB(SRAM)
 ---
 
 # RV-STAR

--- a/STAR64/README.md
+++ b/STAR64/README.md
@@ -3,6 +3,7 @@ vendor: pine64_star64
 product: Star64
 cpu: JH7110
 cpu_core: SiFive U74 + SiFive S7 + SiFive E24
+ram: 2G/4G/8G
 ---
 
 # Star64

--- a/TTGO_T_Display/README.md
+++ b/TTGO_T_Display/README.md
@@ -2,6 +2,7 @@
 product: TTGO T-Display-GD32
 cpu: GD32VF103
 cpu_core: Nuclei Bumblebee
+ram: 4MB/16MB
 ---
 
 # TTGO T-Display-GD32
@@ -32,4 +33,3 @@ cpu_core: Nuclei Bumblebee
 [RT-Thread]: ./RT-Thread/README.md
 [ThreadX]: ./ThreadX/README.md
 [uCOSII]: ./uCOSII/README.md
-

--- a/Tang_Mega_138K/README.md
+++ b/Tang_Mega_138K/README.md
@@ -2,6 +2,7 @@
 product: Tang Mega 138K
 cpu: AE350
 cpu_core: AndesCore AX45MP
+ram: 1G
 ---
 
 # Tang Mega 138K Pro

--- a/TinyVision/README.md
+++ b/TinyVision/README.md
@@ -2,6 +2,7 @@
 product: TinyVision
 cpu: V851se
 cpu_core: XuanTie E907 + ARM Cortex-A7
+ram: 64MB/128MB/256MB
 ---
 
 # TinyVision

--- a/Unmatched/README.md
+++ b/Unmatched/README.md
@@ -2,6 +2,7 @@
 product: HiFive Unmatched
 cpu: U740
 cpu_core: SiFive U74 + SiFive S7
+ram: 16GB
 ---
 
 # HiFive Unmatched

--- a/V853/README.md
+++ b/V853/README.md
@@ -2,6 +2,7 @@
 product: AllWinner V853
 cpu: V853
 cpu_core: XuanTie E907 + ARM Cortex-A7
+ram: 512MB
 ---
 
 # Allwinner V853 Development Board

--- a/Vega/README.md
+++ b/Vega/README.md
@@ -2,6 +2,7 @@
 product: Milk-V Vega
 cpu: FSL1030M
 cpu_core: Nuclei UX608
+ram: /
 ---
 
 # Milk-V Vega

--- a/VisionFive/README.md
+++ b/VisionFive/README.md
@@ -2,6 +2,7 @@
 product: VisionFive
 cpu: JH7100
 cpu_core: SiFive U74 + SiFive E24
+ram: 2G/4G/8G
 ---
 
 # StarFive VisionFive

--- a/VisionFive2/README.md
+++ b/VisionFive2/README.md
@@ -2,6 +2,7 @@
 product: VisionFive 2
 cpu: JH7110
 cpu_core: SiFive U74 + SiFive S7 + SiFive E24
+ram: 2G/4G/8G
 ---
 
 # StarFive VisionFive 2
@@ -68,14 +69,14 @@ cpu_core: SiFive U74 + SiFive S7 + SiFive E24
 - eweOS
     - Source code Link: https://github.com/panglars/eweos-vf2-mainline
     - Reference Installation Document: https://github.com/panglars/eweos-vf2-mainline/blob/main/README.md
-- irradium 3.7 
+- irradium 3.7
     - Download Link: https://dl.irradium.org/irradium/images/visionfive_2/
     - Reference Installation Document: https://dl.irradium.org/irradium/images/visionfive_2/README.TXT
 - Guix System
     - Download Link: https://ci.guix.gnu.org/search/latest?query=spec:images+status:success+system:x86_64-linux+visionfive2-barebones-raw-image
     - Reference Installation Document: https://github.com/Z572/guix-riscv-channel#visionfive2milk-v-mars
-    
-    
+
+
 ### Hardware Information
 
 - StarFive VisionFive 2

--- a/YouMuPI/README.md
+++ b/YouMuPI/README.md
@@ -2,6 +2,7 @@
 product: YuzukiHD-Lizard
 cpu: V851s
 cpu_core: XuanTie E907 + ARM Cortex-A7
+ram: 64MB
 ---
 
 # Yuzuki PI-Lizard

--- a/mangopi_mq/README.md
+++ b/mangopi_mq/README.md
@@ -2,6 +2,7 @@
 product: Mangopi MQ
 cpu: D1s
 cpu_core: XuanTie C906
+ram: 64MB
 ---
 
 # Mangopi MQ

--- a/mangopi_mq_pro/README.md
+++ b/mangopi_mq_pro/README.md
@@ -2,6 +2,7 @@
 product: MangoPi MQ Pro
 cpu: D1 (D1-H)
 cpu_core: XuanTie C906
+ram: 512MB/1G
 ---
 
 # MangoPi MQ Pro


### PR DESCRIPTION
# Welcome to Pull Request

Thank you for your contribution! Please refer to the [contributing guidelines](../CONTRIBUTING.md) for more details.

## If you are working on the support-matrix report

We appreciate your effort in improving the support matrix. To generate the SVG image locally, you can use:

```sh
python assets/generate_svgimage.py -p . -o assets/output --html https://${{ github.repository_owner }}.github.io/support-matrix
```

For internationalization (i18n) SVG generation  test, simply add the `-l zh` option.

If you're creating a new report, please refer to our templates:
- [Board report template](../report-template/[board-name]/README.md)
- [OS report template](../report-template/[board-name]/[os-name]/README.md)

### Checklist
- [X] SVG table generation passes successfully
- [X] Appropriate changes to documentation are included in the PR
- [ ] i18n for documentation (optional)

## If you are working on the assets toolchain

Fixes #<issue_number_goes_here>

> We recommend opening an issue for discussion before making significant changes.

### Checklist
- [ ] Changes to workflow/codes are fully tested
- [X] Appropriate changes to documentation are included in the PR
- [ ] This fixes an issue
- [X] New feature added

# Info about this PR

This PR introduces RAM information for various boards to be displayed on the [frontend](https://matrix.ruyisdk.org) platform.

## Formatting

- Standard Development Boards: `2G/4G/8G`
- Embedded Devices: `..KB(SRAM) + ..KB/MB(SPRAM/Flash)`
- Networking Devices (e.g., MilkV Vega): the `ram` field is represented by a simple `/`
