### PR TITLE
Fix RAM information for some boards

### DIFF
--- a/CH32V203/README.md
+++ b/CH32V203/README.md
@@ -2,7 +2,7 @@
 product: CH32V203-EVT
 cpu: CH32V203
 cpu_core: QingKe V4B
-ram: 64KB(SRAM)
+ram: 20KB(SRAM)
 ---
 
 

--- a/Duo_S/README.md
+++ b/Duo_S/README.md
@@ -3,7 +3,7 @@ vendor: milkv_duos
 product: Milk-V Duo S
 cpu: SG2000
 cpu_core: XuanTie C906 + ARM Cortex-A53
-ram: 256MB
+ram: 512MB
 ---
 
 # Milk-V Duo S

--- a/LicheeRV_Nano/README.md
+++ b/LicheeRV_Nano/README.md
@@ -3,7 +3,7 @@ vendor: sipeed_licheervnano
 product: LicheeRV Nano
 cpu: SG2002
 cpu_core: XuanTie C906 + ARM Cortex-A53
-ram: 2G
+ram: 256MB
 ---
 
 # LicheeRV Nano

--- a/TTGO_T_Display/README.md
+++ b/TTGO_T_Display/README.md
@@ -2,7 +2,7 @@
 product: TTGO T-Display-GD32
 cpu: GD32VF103
 cpu_core: Nuclei Bumblebee
-ram: 4MB/16MB
+ram: 32KB(SRAM)
 ---
 
 # TTGO T-Display-GD32

--- a/TinyVision/README.md
+++ b/TinyVision/README.md
@@ -2,7 +2,7 @@
 product: TinyVision
 cpu: V851se
 cpu_core: XuanTie E907 + ARM Cortex-A7
-ram: 64MB/128MB/256MB
+ram: 64MB
 ---
 
 # TinyVision

--- a/VisionFive/README.md
+++ b/VisionFive/README.md
@@ -2,7 +2,7 @@
 product: VisionFive
 cpu: JH7100
 cpu_core: SiFive U74 + SiFive E24
-ram: 2G/4G/8G
+ram: 8G
 ---
 
 # StarFive VisionFive


### PR DESCRIPTION
# Welcome to Pull Request

Thank you for your contribution! Please refer to the [contributing guidelines](../CONTRIBUTING.md) for more details.

## If you are working on the support-matrix report

We appreciate your effort in improving the support matrix. To generate the SVG image locally, you can use:

```sh
python assets/generate_svgimage.py -p . -o assets/output --html https://${{ github.repository_owner }}.github.io/support-matrix
```

For internationalization (i18n) SVG generation  test, simply add the `-l zh` option.

If you're creating a new report, please refer to our templates:
- [Board report template](../report-template/[board-name]/README.md)
- [OS report template](../report-template/[board-name]/[os-name]/README.md)

### Checklist
- [X] SVG table generation passes successfully
- [X] Appropriate changes to documentation are included in the PR
- [ ] i18n for documentation (optional)

# Info

This PR fixes some wrong information for the boards

- CH32V203: [Ref](https://www.wch.cn/products/CH32V203.html)
- DuoS: [Ref](https://milkv.io/zh/docs/duo/getting-started/duos)
- RV Nano: [Ref](https://wiki.sipeed.com/hardware/zh/lichee/RV_Nano/1_intro.html)
- TinyVersion: [Ref](https://tinyvision.yuzukihd.top/#/)
  - 128MB/256MB is still in plan, so removed
- StarFive: [Ref](https://www.starfivetech.com/en/site/boards)