### PR TITLE
Add NixOS test reports for Mars.

### DIFF
--- a/Mars/NixOS/README.md
+++ b/Mars/NixOS/README.md
@@ -1,0 +1,161 @@
+---
+sys: nixos
+sys_ver: "25.05"
+sys_var: null
+
+status: basic
+last_update: 2025-04-18
+---
+
+# NixOS Milk-V Mars Test Report
+
+## Test Environment
+
+### Hardware Information
+
+- Development Board: Milk-V Mars (8GB RAM)
+- Other Hardware:
+  - A USB power adapter and A USB-A to C or C to C cable
+  - A microSD card
+  - A USB to UART debugger (e.g., CH340, CH341, FT2232, etc.)
+
+### Operating System Information
+
+- OS Version: NixOS 25.05 (Warbler) (Build ID: 20250328.2cc0d7f)
+- Download Link: <https://hydra.nichi.co/build/1426425/download/1/nixos-image-sd-card-25.05.20250328.2cc0d7f-riscv64-linux.img.zst>
+- Reference Installation Document:
+  - <https://milkv.io/zh/docs/mars/getting-started/boot>
+  - <https://github.com/NickCao/nixos-riscv>
+
+## Installation Steps
+
+### Flashing the Image
+
+Use `zstd` command to decompress the image,  and then use `dd` command or `balenaEtcher` software to flash the image to the microSD card.
+
+Here, `/dev/sdc` corresponds to the storage device.
+
+```bash
+wget https://hydra.nichi.co/build/1426425/download/1/nixos-image-sd-card-25.05.20250328.2cc0d7f-riscv64-linux.img.zst
+
+zstd -d nixos-image-sd-card-25.05.20250328.2cc0d7f-riscv64-linux.img.zst
+
+sudo dd if=nixos-image-sd-card-25.05.20250328.2cc0d7f-riscv64-linux.img of=/dev/sdc bs=1M status=progress
+
+sync
+```
+
+### Logging into the System
+
+Logging into the system via the serial port.
+
+Default username: `nixos` (automatic login)
+
+No password by default
+
+## Expected Results
+
+The system should boot normally, allowing login via the onboard serial port.
+
+## Actual Results
+
+The system starts normally and the output is successfully viewed through the serial port.
+
+### Boot Information
+
+```log
+<<< Welcome to NixOS sd-card-25.05.20250328.2cc0d7f (riscv64) - ttyS0 >>>
+The "nixos" and "root" accounts have empty passwords.
+
+To log in over ssh you must set a password for either "nixos" or "root"
+with `passwd` (prefix with `sudo` for "root"), or add your public key to
+/home/nixos/.ssh/authorized_keys or /root/.ssh/authorized_keys.
+
+If you need a wireless connection, type
+`sudo systemctl start wpa_supplicant` and configure a
+network using `wpa_cli`. See the NixOS manual for details.
+
+
+Run 'nixos-help' for the NixOS manual.
+
+nixos login: nixos (automatic login)
+
+
+[nixos@nixos:~]$ cat /etc/os-release
+ANSI_COLOR="0;38;2;126;186;228"
+BUG_REPORT_URL="https://github.com/NixOS/nixpkgs/issues"
+BUILD_ID="25.05.20250328.2cc0d7f"
+CPE_NAME="cpe:/o:nixos:nixos:25.05"
+DEFAULT_HOSTNAME=nixos
+DOCUMENTATION_URL="https://nixos.org/learn.html"
+HOME_URL="https://nixos.org/"
+ID=nixos
+ID_LIKE=""
+IMAGE_ID=""
+IMAGE_VERSION=""
+LOGO="nix-snowflake"
+NAME=NixOS
+PRETTY_NAME="NixOS 25.05 (Warbler)"
+SUPPORT_URL="https://nixos.org/community.html"
+VARIANT=""
+VARIANT_ID=installer
+VENDOR_NAME=NixOS
+VENDOR_URL="https://nixos.org/"
+VERSION="25.05 (Warbler)"
+VERSION_CODENAME=warbler
+VERSION_ID="25.05"
+
+[nixos@nixos:~]$ uname -a
+Linux nixos 6.14.0 #1-NixOS SMP Mon Mar 24 14:02:41 UTC 2025 riscv64 GNU/Linux
+
+[nixos@nixos:~]$ cat /proc/cpuinfo
+processor       : 0
+hart            : 3
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+
+processor       : 1
+hart            : 1
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+
+processor       : 2
+hart            : 2
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+
+processor       : 3
+hart            : 4
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+```
+
+## Test Criteria
+
+Successful: The actual result matches the expected result.
+
+Failed: The actual result does not match the expected result.
+
+## Test Conclusion
+
+Test successful.

--- a/Mars/NixOS/README_zh.md
+++ b/Mars/NixOS/README_zh.md
@@ -1,0 +1,152 @@
+# NixOS Milk-V Mars 测试报告
+
+## 测试环境
+
+### 硬件信息
+
+- 开发板：Milk-V Mars (8GB RAM)
+- 其他硬件：
+  - USB 电源适配器和USB-A to C 或 C to C 线缆一条
+  - microSD 卡一张
+  - USB to UART 调试器一个（如：CH340, CH341, FT2232 等）
+
+### 操作系统信息
+
+- 操作系统版本：NixOS 25.05 (Warbler) (Build ID: 20250328.2cc0d7f)
+- 下载链接：<https://hydra.nichi.co/build/1426425/download/1/nixos-image-sd-card-25.05.20250328.2cc0d7f-riscv64-linux.img.zst>
+- 参考安装文档：
+  - <https://milkv.io/zh/docs/mars/getting-started/boot>
+  - <https://github.com/NickCao/nixos-riscv>
+
+## 安装步骤
+
+### 刷写镜像
+
+使用 `zstd` 命令解压镜像，并使用 `dd` 命令或 `balenaEtcher` 软件将镜像写入 microSD 卡。
+
+其中，`/dev/sdc` 为存储卡对应设备。
+
+```bash
+wget https://hydra.nichi.co/build/1426425/download/1/nixos-image-sd-card-25.05.20250328.2cc0d7f-riscv64-linux.img.zst
+
+zstd -d nixos-image-sd-card-25.05.20250328.2cc0d7f-riscv64-linux.img.zst
+
+sudo dd if=nixos-image-sd-card-25.05.20250328.2cc0d7f-riscv64-linux.img of=/dev/sdc bs=1M status=progress
+
+sync
+```
+
+### 登录系统
+
+通过串口登录系统。
+
+默认用户名： `nixos` (自动登录)
+
+默认无密码
+
+## 预期结果
+
+系统正常启动，能够通过板载串口登录。
+
+## 实际结果
+
+系统正常启动，成功通过串口查看输出。
+
+### 启动信息
+
+```log
+<<< Welcome to NixOS sd-card-25.05.20250328.2cc0d7f (riscv64) - ttyS0 >>>
+The "nixos" and "root" accounts have empty passwords.
+
+To log in over ssh you must set a password for either "nixos" or "root"
+with `passwd` (prefix with `sudo` for "root"), or add your public key to
+/home/nixos/.ssh/authorized_keys or /root/.ssh/authorized_keys.
+
+If you need a wireless connection, type
+`sudo systemctl start wpa_supplicant` and configure a
+network using `wpa_cli`. See the NixOS manual for details.
+
+
+Run 'nixos-help' for the NixOS manual.
+
+nixos login: nixos (automatic login)
+
+
+[nixos@nixos:~]$ cat /etc/os-release
+ANSI_COLOR="0;38;2;126;186;228"
+BUG_REPORT_URL="https://github.com/NixOS/nixpkgs/issues"
+BUILD_ID="25.05.20250328.2cc0d7f"
+CPE_NAME="cpe:/o:nixos:nixos:25.05"
+DEFAULT_HOSTNAME=nixos
+DOCUMENTATION_URL="https://nixos.org/learn.html"
+HOME_URL="https://nixos.org/"
+ID=nixos
+ID_LIKE=""
+IMAGE_ID=""
+IMAGE_VERSION=""
+LOGO="nix-snowflake"
+NAME=NixOS
+PRETTY_NAME="NixOS 25.05 (Warbler)"
+SUPPORT_URL="https://nixos.org/community.html"
+VARIANT=""
+VARIANT_ID=installer
+VENDOR_NAME=NixOS
+VENDOR_URL="https://nixos.org/"
+VERSION="25.05 (Warbler)"
+VERSION_CODENAME=warbler
+VERSION_ID="25.05"
+
+[nixos@nixos:~]$ uname -a
+Linux nixos 6.14.0 #1-NixOS SMP Mon Mar 24 14:02:41 UTC 2025 riscv64 GNU/Linux
+
+[nixos@nixos:~]$ cat /proc/cpuinfo
+processor       : 0
+hart            : 3
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+
+processor       : 1
+hart            : 1
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+
+processor       : 2
+hart            : 2
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+
+processor       : 3
+hart            : 4
+isa             : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+mmu             : sv39
+uarch           : sifive,u74-mc
+mvendorid       : 0x489
+marchid         : 0x8000000000000007
+mimpid          : 0x4210427
+hart isa        : rv64imafdc_zicntr_zicsr_zifencei_zihpm_zca_zcd_zba_zbb
+```
+
+## 测试判定标准
+
+测试成功：实际结果与预期结果相符。
+
+测试失败：实际结果与预期结果不符。
+
+## 测试结论
+
+测试成功

--- a/Mars/README.md
+++ b/Mars/README.md
@@ -34,6 +34,11 @@ ram: 1G/2G/4G/8G
   - Reference Installation Document:
     1. <https://milkv.io/zh/docs/mars/getting-started/boot>
     2. <https://images.fedoravforce.org/Mars>
+- NixOS 25.05
+  - Download Link: <https://hydra.nichi.co/build/1426425/download/1/nixos-image-sd-card-25.05.20250328.2cc0d7f-riscv64-linux.img.zst>
+  - Reference Installation Document:
+    - <https://milkv.io/zh/docs/mars/getting-started/boot>
+    - <https://github.com/NickCao/nixos-riscv>
 
 ### Hardware Information
 
@@ -45,12 +50,13 @@ ram: 1G/2G/4G/8G
 | ---------------------- | ------------ | -------------------------------------------- |
 | Debian Image Boot      | N/A          | [Successful][Debian] (Milk-V Official Image) |
 | BuildRoot Build & Boot | N/A          | [Successful][BuildRoot]                      |
-| Ubuntu Image Boot      | N/A          | [Successful][Ubuntu]                                |
-| Ubuntu LTS Image Boot  | N/A          | [Successful][Ubuntu LTS]                            |
-| Deepin Image Boot      | N/A          | [Successful][Deepin]                                |
-| eweOS Image Boot       | N/A          | [Successful][eweOS]                                |
-| Fedora Image Boot       | N/A          | [Successful][Fedora]                                |
-| Guix Image Boot       | N/A          | [Successful][Guix]                                |
+| Ubuntu Image Boot      | N/A          | [Successful][Ubuntu]                         |
+| Ubuntu LTS Image Boot  | N/A          | [Successful][Ubuntu LTS]                     |
+| Deepin Image Boot      | N/A          | [Successful][Deepin]                         |
+| eweOS Image Boot       | N/A          | [Successful][eweOS]                          |
+| Fedora Image Boot      | N/A          | [Successful][Fedora]                         |
+| Guix Image Boot        | N/A          | [Successful][Guix]                           |
+| NixOS Image Boot       | N/A          | [Successful][NixOS]                          |
 
 [Debian]: ./Debian/README.md
 [BuildRoot]: ./BuildRoot/README.md
@@ -60,3 +66,4 @@ ram: 1G/2G/4G/8G
 [eweOS]: ./eweOS/README.md
 [Fedora]: ./Fedora/README.md
 [Guix]: ./Guix/README.md
+[NixOS]: ./NixOS/README.md

--- a/Mars/README_zh.md
+++ b/Mars/README_zh.md
@@ -29,6 +29,11 @@
 - Guix
   - 下载链接：<https://ci.guix.gnu.org/search/latest?query=spec:images+status:success+system:x86_64-linux+visionfive2-barebones-raw-image>
   - 参考安装文档：<https://milkv.iso/zh/docs/mars/getting-started/boot>
+- NixOS 25.05
+  - 下载链接：<https://hydra.nichi.co/build/1426425/download/1/nixos-image-sd-card-25.05.20250328.2cc0d7f-riscv64-linux.img.zst>
+  - 参考安装文档：
+    - <https://milkv.io/zh/docs/mars/getting-started/boot>
+    - <https://github.com/NickCao/nixos-riscv>
 
 ### 硬件开发板信息
 
@@ -46,6 +51,7 @@
 | eweOS 镜像启动       | N/A      | [成功][eweOS]                     |
 | Fedora 镜像启动      | N/A      | [成功][Fedora]                     |
 | Guix 镜像启动        | N/A      | [成功][Guix]                     |
+| NixOS 镜像启动       | N/A      | [成功][NixOS]                     |
 
 [Debian]: ./Debian/README_zh.md
 [BuildRoot]: ./BuildRoot/README_zh.md
@@ -55,3 +61,4 @@
 [eweOS]: ./eweOS/README_zh.md
 [Fedora]: ./Fedora/README_zh.md
 [Guix]: ./Guix/README_zh.md
+[NixOS]: ./NixOS/README.md


### PR DESCRIPTION
# Welcome to Pull Request

Thank you for your contribution! Please refer to the [contributing guidelines](../CONTRIBUTING.md) for more details.

## If you are working on the support-matrix report

We appreciate your effort in improving the support matrix. To generate the SVG image locally, you can use:

```sh
python assets/generate_svgimage.py -p . -o assets/output --html https://${{ github.repository_owner }}.github.io/support-matrix
```

For internationalization (i18n) SVG generation  test, simply add the `-l zh` option.

If you're creating a new report, please refer to our templates:
- [Board report template](../report-template/[board-name]/README.md)
- [OS report template](../report-template/[board-name]/[os-name]/README.md)

### Checklist
- [x] SVG table generation passes successfully
- [x] Appropriate changes to documentation are included in the PR
- [x] i18n for documentation (optional)
