### PR TITLE
DuoS: Bump FreeRTOS to 1.1.4

### DIFF
--- a/Duo_S/FreeRTOS/README.md
+++ b/Duo_S/FreeRTOS/README.md
@@ -4,7 +4,7 @@ sys_ver: null
 sys_var: null
 
 status: basic
-last_update: 2024-06-21
+last_update: 2025-04-28
 ---
 
 # FreeRTOS Milk-V Duo S Test Report
@@ -13,8 +13,8 @@ last_update: 2024-06-21
 
 ### Operating System Information
 
-- Build System: Ubuntu 22.04.4 LTS x86_64
-- System Version: Duo-V1.1.0
+- Build System: Ubuntu 24.04 LTS x86_64
+- System Version: Duo-V1.1.4
 - Download Link: https://github.com/milkv-duo/duo-buildroot-sdk/releases
 - Reference Installation Document: https://github.com/milkv-duo/duo-buildroot-sdk
     - FreeRTOS: https://milkv.io/zh/docs/duo/getting-started/rtoscore
@@ -71,27 +71,35 @@ The system should boot normally. Upon logging in via the onboard serial port and
 
 ## Actual Results
 
-The system booted successfully, and login via the onboard serial port was successful. The official Duo S image does not currently support wiringX, so `mailbox_test` did not run correctly, though the system detected the RTOS device.
+The system booted successfully, and login via the onboard serial port was achieved without issues.
+
+The mailbox_test binary executed successfully, and the behavior of the LED matched expectations.
 
 ### Boot Information
 
 ```log
+[root@milkv-duo]~#
 [root@milkv-duo]~# ls
 mailbox_test
-[root@milkv-duo]~# insmod: can't insert '/mnt/system/ko/aic8800_fdrv.ko': No such device
 [root@milkv-duo]~# ./mailbox_test
-Error loading shared library libwiringx.so: No such file or directory (needed by ./mailbox_test)
 [root@milkv-duo]~# find / -name *rtos*
-find: /proc/338: No such file or directory
+find: /proc/355: No such file or directory
+/sys/class/misc/cvi-rtos-cmdqu
+/sys/class/cvi-rtos-cmdqu
 /sys/devices/platform/1900000.rtos_cmdqu
+/sys/devices/virtual/misc/cvi-rtos-cmdqu
 /sys/bus/platform/devices/1900000.rtos_cmdqu
+/sys/bus/platform/drivers/cvi-rtos-cmdqu
+/sys/bus/platform/drivers/cvi-rtos-cmdqu/1900000.rtos_cmdqu
 /sys/firmware/devicetree/base/rtos_cmdqu
+/sys/firmware/devicetree/base/reserved-memory/rtos_dram@0x9fe00000
+/dev/cvi-rtos-cmdqu
 [root@milkv-duo]~#
 ```
 
 Screen recording:
 
-[![asciicast](https://asciinema.org/a/y8YaDpY5YnKWgw4ydZPVDf4YB.svg)](https://asciinema.org/a/y8YaDpY5YnKWgw4ydZPVDf4YB)
+[![asciicast](https://asciinema.org/a/3JlGE9DBVemEnRqIffzKhNKcT.svg)](https://asciinema.org/a/3JlGE9DBVemEnRqIffzKhNKcT)
 
 ## Test Criteria
 
@@ -101,4 +109,4 @@ Failed: The actual result does not match the expected result.
 
 ## Test Conclusion
 
-Test partial success.
+Test successful.

--- a/Duo_S/FreeRTOS/README_zh.md
+++ b/Duo_S/FreeRTOS/README_zh.md
@@ -4,8 +4,8 @@
 
 ### 操作系统信息
 
-- 构建系统：Ubuntu 22.04.4 LTS x86_64
-- 系统版本：Duo-V1.1.0
+- 构建系统：Ubuntu 24.04 LTS x86_64
+- 系统版本：Duo-V1.1.4
 - 下载链接：https://github.com/milkv-duo/duo-buildroot-sdk/releases
 - 参考安装文档：https://github.com/milkv-duo/duo-buildroot-sdk
     - FreeRTOS: https://milkv.io/zh/docs/duo/getting-started/rtoscore
@@ -62,27 +62,35 @@ sudo eject /dev/sdX2
 
 ## 实际结果
 
-系统正常启动，成功通过板载串口登录，Duo S 官方镜像目前暂不支持 wiringX，`mailbox_test` 未能正常运行，但系统已检测到 rtos 设备。
+系统启动正常，并能顺利通过板载串口登录。
+
+`mailbox_test` 测试程序可以成功执行，LED 灯的行为符合预期。
 
 ### 启动信息
 
 ```log
+[root@milkv-duo]~#
 [root@milkv-duo]~# ls
 mailbox_test
-[root@milkv-duo]~# insmod: can't insert '/mnt/system/ko/aic8800_fdrv.ko': No such device
 [root@milkv-duo]~# ./mailbox_test
-Error loading shared library libwiringx.so: No such file or directory (needed by ./mailbox_test)
 [root@milkv-duo]~# find / -name *rtos*
-find: /proc/338: No such file or directory
+find: /proc/355: No such file or directory
+/sys/class/misc/cvi-rtos-cmdqu
+/sys/class/cvi-rtos-cmdqu
 /sys/devices/platform/1900000.rtos_cmdqu
+/sys/devices/virtual/misc/cvi-rtos-cmdqu
 /sys/bus/platform/devices/1900000.rtos_cmdqu
+/sys/bus/platform/drivers/cvi-rtos-cmdqu
+/sys/bus/platform/drivers/cvi-rtos-cmdqu/1900000.rtos_cmdqu
 /sys/firmware/devicetree/base/rtos_cmdqu
+/sys/firmware/devicetree/base/reserved-memory/rtos_dram@0x9fe00000
+/dev/cvi-rtos-cmdqu
 [root@milkv-duo]~#
 ```
 
 屏幕录像：
 
-[![asciicast](https://asciinema.org/a/y8YaDpY5YnKWgw4ydZPVDf4YB.svg)](https://asciinema.org/a/y8YaDpY5YnKWgw4ydZPVDf4YB)
+[![asciicast](https://asciinema.org/a/3JlGE9DBVemEnRqIffzKhNKcT.svg)](https://asciinema.org/a/3JlGE9DBVemEnRqIffzKhNKcT)
 
 ## 测试判定标准
 
@@ -92,4 +100,4 @@ find: /proc/338: No such file or directory
 
 ## 测试结论
 
-测试部分成功。
+测试成功。


### PR DESCRIPTION
# Welcome to Pull Request

Thank you for your contribution! Please refer to the [contributing guidelines](../CONTRIBUTING.md) for more details.

## If you are working on the support-matrix report

We appreciate your effort in improving the support matrix. To generate the SVG image locally, you can use:

```sh
python assets/generate_svgimage.py -p . -o assets/output --html https://${{ github.repository_owner }}.github.io/support-matrix
```

For internationalization (i18n) SVG generation  test, simply add the `-l zh` option.

If you're creating a new report, please refer to our templates:
- [Board report template](../report-template/[board-name]/README.md)
- [OS report template](../report-template/[board-name]/[os-name]/README.md)

### Checklist
- [ ] SVG table generation passes successfully
- [ ] Appropriate changes to documentation are included in the PR
- [ ] i18n for documentation (optional)

## If you are working on the assets toolchain

Fixes #<issue_number_goes_here>

> We recommend opening an issue for discussion before making significant changes.

### Checklist
- [ ] Changes to workflow/codes are fully tested
- [ ] Appropriate changes to documentation are included in the PR
- [ ] This fixes an issue
- [ ] New feature added
