### PR TITLE
Star64/NuttX: Bump to 12.9.0

### DIFF
--- a/STAR64/NuttX/README.md
+++ b/STAR64/NuttX/README.md
@@ -1,6 +1,6 @@
 ---
 sys: nuttx
-sys_ver: null
+sys_ver: "12.9.0"
 sys_var: null
 
 status: cft
@@ -33,6 +33,7 @@ last_update: 2024-06-21
 
 Get the toolchain:
 ```bash
+sudo apt install kconfig-frontends genromfs u-boot-tools
 wget https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.12/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
 tar -xvzf riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
 export PATH=path/to/toolchain/bin:$PATH
@@ -41,8 +42,8 @@ export PATH=path/to/toolchain/bin:$PATH
 Clone the repository and configure:
 ```bash
 mkdir nuttx && cd nuttx
-git clone https://github.com/apache/nuttx.git nuttx
-git clone https://github.com/apache/nuttx-apps.git apps
+git clone -b nuttx-12.9.0 https://github.com/apache/nuttx.git nuttx
+git clone -b nuttx-12.9.0 https://github.com/apache/nuttx-apps.git apps
 ```
 
 ### Building NuttX
@@ -50,7 +51,6 @@ git clone https://github.com/apache/nuttx-apps.git apps
 Compile nuttx.bin:
 ```bash
 cd nuttx
-make distclean
 ./tools/configure.sh star64:nsh
 make -j$(nproc)
 riscv64-unknown-elf-objcopy -O binary nuttx nuttx.bin
@@ -131,13 +131,6 @@ cat << EOF > nuttx.its
 EOF
 ```
 
-Ensure you have u-boot-tools installed on your system:
-```bash
-# sudo apt install u-boot-tools
-# sudo pacman -S uboot-tools
-# sudo dnf install u-boot-tools
-```
-
 Create the fit:
 ```bash
 mkimage -f nuttx.its -A riscv -O linux -T flat_dt starfiveu.fit
@@ -149,14 +142,6 @@ Download the SD card image and flash:
 ```bash
 wget https://github.com/starfive-tech/VisionFive2/releases/download/JH7110_VF2_515_v5.11.3/sdcard.img
 sudo dd if=sdcard.img of=/dev/your/device bs=1M status=progress
-```
-
-### Flashing the Image
-
-Flash the SBI environment onto the SD card:
-```bash
-unxz -k canmv230-sdcard.img.xz
-sudo dd if=canmv230-sdcard.img of=/dev/your/sdcard bs=1M status=progress
 ```
 
 Replace the fit file:

--- a/STAR64/NuttX/README_zh.md
+++ b/STAR64/NuttX/README_zh.md
@@ -24,6 +24,7 @@
 
 获取工具链：
 ```bash
+sudo apt install kconfig-frontends genromfs u-boot-tools
 wget https://static.dev.sifive.com/dev-tools/freedom-tools/v2020.12/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
 tar -xvzf riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14.tar.gz
 export PATH=path/to/toolchain/bin:$PATH
@@ -32,15 +33,14 @@ export PATH=path/to/toolchain/bin:$PATH
 clone 仓库并进行配置：
 ```bash
 mkdir nuttx && cd nuttx
-git clone https://github.com/apache/nuttx.git nuttx
-git clone https://github.com/apache/nuttx-apps.git apps
+git clone -b nuttx-12.9.0 https://github.com/apache/nuttx.git nuttx
+git clone -b nuttx-12.9.0 https://github.com/apache/nuttx-apps.git apps
 ```
 ### 构建 NuttX
 
 编译 nuttx.bin：
 ```bash
 cd nuttx
-make distclean
 ./tools/configure.sh star64:nsh
 make -j$(nproc)
 riscv64-unknown-elf-objcopy -O binary nuttx nuttx.bin
@@ -121,13 +121,6 @@ cat << EOF > nuttx.its
 EOF
 ```
 
-确认你系统上安装了 u-boot-tools：
-```bash
-# sudo apt install u-boot-tools
-# sudo pacman -S uboot-tools
-# sudo dnf install u-boot-tools
-```
-
 创建 fit：
 ```bash
 mkimage -f nuttx.its -A riscv -O linux -T flat_dt starfiveu.fit
@@ -139,14 +132,6 @@ mkimage -f nuttx.its -A riscv -O linux -T flat_dt starfiveu.fit
 ```bash
 wget https://github.com/starfive-tech/VisionFive2/releases/download/JH7110_VF2_515_v5.11.3/sdcard.img
 sudo dd if=sdcard.img of=/dev/your/device bs=1M status=progress
-```
-
-### 烧写镜像
-
-在 SD 卡上烧写 SBI 环境：
-```bash
-unxz -k canmv230-sdcard.img.xz
-sudo dd if=canmv230-sdcard.img of=/dev/your/sdcard bs=1M status=progress
 ```
 
 替换 fit 文件：


### PR DESCRIPTION
# Welcome to Pull Request

Thank you for your contribution! Please refer to the [contributing guidelines](../CONTRIBUTING.md) for more details.

## If you are working on the support-matrix report

We appreciate your effort in improving the support matrix. To generate the SVG image locally, you can use:

```sh
python assets/generate_svgimage.py -p . -o assets/output --html https://${{ github.repository_owner }}.github.io/support-matrix
```

For internationalization (i18n) SVG generation  test, simply add the `-l zh` option.

If you're creating a new report, please refer to our templates:
- [Board report template](../report-template/[board-name]/README.md)
- [OS report template](../report-template/[board-name]/[os-name]/README.md)

### Checklist
- [x] SVG table generation passes successfully
- [x] Appropriate changes to documentation are included in the PR
- [x] i18n for documentation (optional)

## If you are working on the assets toolchain

Fixes #<issue_number_goes_here>

> We recommend opening an issue for discussion before making significant changes.

### Checklist
- [ ] Changes to workflow/codes are fully tested
- [ ] Appropriate changes to documentation are included in the PR
- [ ] This fixes an issue
- [ ] New feature added
