### PR TITLE
DuoS: dump Debian to 1.6.23

### DIFF
--- a/Duo_S/Debian/README.md
+++ b/Duo_S/Debian/README.md
@@ -4,7 +4,7 @@ sys_ver: null
 sys_var: null
 
 status: basic
-last_update: 2025-04-13
+last_update: 2025-05-27
 ---
 
 # Debian Milk-V Duo S Test Report
@@ -13,7 +13,7 @@ last_update: 2025-04-13
 
 ### Operating System Information
 
-- Download Link: https://github.com/scpcom/sophgo-sg200x-debian/releases/tag/v1.6.10
+- Download Link: https://github.com/scpcom/sophgo-sg200x-debian/releases/tag/v1.6.23
 - Reference Installation Document: https://github.com/scpcom/sophgo-sg200x-debian
 
 ### Hardware Information
@@ -50,11 +50,11 @@ The system boots up normally and login through the onboard serial port is succes
 ### Boot Information
 
 ```log
-Debian GNU/Linux trixie/sid duos-ee00 ttyS0
+Debian GNU/Linux 13 duos-a0d7 ttyS0
 
-duos-ee00 login: debian
+duos-a0d7 login: debian
 Password:
-Linux duos-ee00 5.10.235-20250403-6+duos #1 PREEMPT Sun Apr 13 01:35:51 UTC 2025 riscv64
+Linux duos-a0d7 5.10.235-20250430-6+duos #1 PREEMPT Sun May 25 13:36:19 UTC 2025 riscv64
 
 The programs included with the Debian GNU/Linux system are free software;
 the exact distribution terms for each program are described in the
@@ -62,24 +62,31 @@ individual files in /usr/share/doc/*/copyright.
 
 Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
 permitted by applicable law.
-debian@duos-ee00:~$ cat /etc/os-release
-PRETTY_NAME="Debian GNU/Linux trixie/sid"
+debian@duos-a0d7:~$ cat /etc/os-release
+PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
 NAME="Debian GNU/Linux"
+VERSION_ID="13"
+VERSION="13 (trixie)"
 VERSION_CODENAME=trixie
+DEBIAN_VERSION_FULL=13.0
 ID=debian
 HOME_URL="https://www.debian.org/"
 SUPPORT_URL="https://www.debian.org/support"
 BUG_REPORT_URL="https://bugs.debian.org/"
-debian@duos-ee00:~$ uname -a
-Linux duos-ee00 5.10.235-20250403-6+duos #1 PREEMPT Sun Apr 13 01:35:51 UTC 2025 riscv64 GNU/Linux
-debian@duos-ee00:~$ cat /proc/cpuinfo
+debian@duos-a0d7:~$ uname -a
+Linux duos-a0d7 5.10.235-20250430-6+duos #1 PREEMPT Sun May 25 13:36:19 UTC 2025 riscv64 GNU/Linux
+debian@duos-a0d7:~$ cat /proc/cpuinfo
 processor       : 0
 hart            : 0
 isa             : rv64imafdvcsu
 mmu             : sv39
 
-debian@duos-ee00:~$
+debian@duos-a0d7:~$
 ```
+
+Screen recording:
+
+[![asciicast](https://asciinema.org/a/CbWcHhsyLKZ8jjPRV4WRYOILd.svg)](https://asciinema.org/a/CbWcHhsyLKZ8jjPRV4WRYOILd)
 
 ## Test Criteria
 

--- a/Duo_S/Debian/README_zh.md
+++ b/Duo_S/Debian/README_zh.md
@@ -4,7 +4,7 @@
 
 ### 操作系统信息
 
-- 下载链接：https://github.com/scpcom/sophgo-sg200x-debian/releases/tag/v1.6.10
+- 下载链接：https://github.com/scpcom/sophgo-sg200x-debian/releases/tag/v1.6.23
 - 参考安装文档：https://github.com/scpcom/sophgo-sg200x-debian
 
 ### 硬件信息
@@ -41,11 +41,11 @@ sudo dd if=duos-e_sd.img of=/dev/sdX bs=1M status=progress
 ### 启动信息
 
 ```log
-Debian GNU/Linux trixie/sid duos-ee00 ttyS0
+Debian GNU/Linux 13 duos-a0d7 ttyS0
 
-duos-ee00 login: debian
+duos-a0d7 login: debian
 Password:
-Linux duos-ee00 5.10.235-20250403-6+duos #1 PREEMPT Sun Apr 13 01:35:51 UTC 2025 riscv64
+Linux duos-a0d7 5.10.235-20250430-6+duos #1 PREEMPT Sun May 25 13:36:19 UTC 2025 riscv64
 
 The programs included with the Debian GNU/Linux system are free software;
 the exact distribution terms for each program are described in the
@@ -53,24 +53,31 @@ individual files in /usr/share/doc/*/copyright.
 
 Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
 permitted by applicable law.
-debian@duos-ee00:~$ cat /etc/os-release
-PRETTY_NAME="Debian GNU/Linux trixie/sid"
+debian@duos-a0d7:~$ cat /etc/os-release
+PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
 NAME="Debian GNU/Linux"
+VERSION_ID="13"
+VERSION="13 (trixie)"
 VERSION_CODENAME=trixie
+DEBIAN_VERSION_FULL=13.0
 ID=debian
 HOME_URL="https://www.debian.org/"
 SUPPORT_URL="https://www.debian.org/support"
 BUG_REPORT_URL="https://bugs.debian.org/"
-debian@duos-ee00:~$ uname -a
-Linux duos-ee00 5.10.235-20250403-6+duos #1 PREEMPT Sun Apr 13 01:35:51 UTC 2025 riscv64 GNU/Linux
-debian@duos-ee00:~$ cat /proc/cpuinfo
+debian@duos-a0d7:~$ uname -a
+Linux duos-a0d7 5.10.235-20250430-6+duos #1 PREEMPT Sun May 25 13:36:19 UTC 2025 riscv64 GNU/Linux
+debian@duos-a0d7:~$ cat /proc/cpuinfo
 processor       : 0
 hart            : 0
 isa             : rv64imafdvcsu
 mmu             : sv39
 
-debian@duos-ee00:~$
+debian@duos-a0d7:~$
 ```
+
+屏幕录像：
+
+[![asciicast](https://asciinema.org/a/CbWcHhsyLKZ8jjPRV4WRYOILd.svg)](https://asciinema.org/a/CbWcHhsyLKZ8jjPRV4WRYOILd)
 
 ## 测试判定标准
 

--- a/Duo_S/README.md
+++ b/Duo_S/README.md
@@ -22,7 +22,7 @@ ram: 512MB
     - NuttX Apps: https://github.com/lupyuen2/wip-nuttx-apps/tree/sg2000
   - Reference Installation Document: https://github.com/lupyuen/nuttx-sg2000
 - Debian
-  - Download Link: https://github.com/Fishwaldo/sophgo-sg200x-debian/releases/tag/v1.4.0
+  - Download Link: https://github.com/scpcom/sophgo-sg200x-debian/releases/tag/v1.6.23
   - Reference Installation Document: https://github.com/Fishwaldo/sophgo-sg200x-debian
 - Zephyr
   - Source Code Link: https://github.com/zephyrproject-rtos/zephyr/tree/main

--- a/Duo_S/README_zh.md
+++ b/Duo_S/README_zh.md
@@ -14,7 +14,7 @@
     - NuttX Apps: https://github.com/lupyuen2/wip-nuttx-apps/tree/sg2000
   - 参考安装文档；https://github.com/lupyuen/nuttx-sg2000
 - Debian
-  - 下载链接：https://github.com/Fishwaldo/sophgo-sg200x-debian/releases/tag/v1.4.0
+  - 下载链接：https://github.com/scpcom/sophgo-sg200x-debian/releases/tag/v1.6.23
   - 参考安装文档：https://github.com/Fishwaldo/sophgo-sg200x-debian
 - Zephyr
   - 源码链接：https://github.com/zephyrproject-rtos/zephyr/tree/main


### PR DESCRIPTION
# Welcome to Pull Request

Thank you for your contribution! Please refer to the [contributing guidelines](../CONTRIBUTING.md) for more details.

## If you are working on the support-matrix report

We appreciate your effort in improving the support matrix. To generate the SVG image locally, you can use:

```sh
python assets/generate_svgimage.py -p . -o assets/output --html https://${{ github.repository_owner }}.github.io/support-matrix
```

For internationalization (i18n) SVG generation  test, simply add the `-l zh` option.

If you're creating a new report, please refer to our templates:
- [Board report template](../report-template/[board-name]/README.md)
- [OS report template](../report-template/[board-name]/[os-name]/README.md)

### Checklist
- [X] SVG table generation passes successfully
- [X] Appropriate changes to documentation are included in the PR
- [X] i18n for documentation (optional)

## If you are working on the assets toolchain

Fixes #<issue_number_goes_here>

> We recommend opening an issue for discussion before making significant changes.

### Checklist
- [ ] Changes to workflow/codes are fully tested
- [ ] Appropriate changes to documentation are included in the PR
- [ ] This fixes an issue
- [ ] New feature added
