### PR TITLE
Duo 256M: update Debian 13.0 test report and fix some typos.

### DIFF
--- a/Duo256m/Debian/README.md
+++ b/Duo256m/Debian/README.md
@@ -1,10 +1,10 @@
 ---
 sys: debian
-sys_ver: sid
+sys_ver: "13.0"
 sys_var: null
 
 status: basic
-last_update: 2025-04-09
+last_update: 2025-05-28
 ---
 
 # Debian Milk-V Duo 256M Test Report
@@ -13,11 +13,12 @@ last_update: 2025-04-09
 
 ### Operating System Information
 
-- System Version: Debian sid
-- Download Link: https://github.com/scpcom/sophgo-sg200x-debian/releases/download/v1.6.7/duo256-e_sd.img.lz4
-- Reference Installation Document: https://github.com/scpcom/sophgo-sg200x-debian/
+- System Version: Debian 13.0
+- Download Link: <https://github.com/scpcom/sophgo-sg200x-debian/releases/download/v1.6.23/duo256-e_sd.img.lz4>
+- Reference Installation Document: <https://github.com/scpcom/sophgo-sg200x-debian/>
 
-> Note: This image is provided by community developers and is not an official image.
+> [!Note]
+> This image is provided by community developers and is not an official image.
 
 ### Hardware Information
 
@@ -32,7 +33,7 @@ last_update: 2025-04-09
 ### Using `dd` to Flash Image to microSD Card
 
 ```shell
-wget https://github.com/scpcom/sophgo-sg200x-debian/releases/download/v1.6.7/duo256-e_sd.img.lz4
+wget https://github.com/scpcom/sophgo-sg200x-debian/releases/download/v1.6.23/duo256-e_sd.img.lz4
 lz4 -d duo256-e_sd.img.lz4
 sudo dd if=duo256-e_sd.img of=/dev/your/device bs=1M status=progress
 ```
@@ -42,6 +43,7 @@ sudo dd if=duo256-e_sd.img of=/dev/your/device bs=1M status=progress
 Logging into the system via the serial port.
 
 Username: `root`
+
 Password: `rv`
 
 ## Expected Results
@@ -55,11 +57,7 @@ The system booted successfully, and login via the serial port was also successfu
 ### Boot Log
 
 ```log
-[   21.658971] RTOS_CMDQU_SEND_WAIT timeout
-[   21.666545] SYS_CMD_INFO_LINUX_INIT_DONE fail
-[   21.695036] communicate with rtos fail
-         Starting systemd-hostnamed.service - Hostname Service...
-[  OK  ] Started systemd-logind.service - User Login Management.
+[   25.075962] communicate with rtos fail
 [  OK  ] Finished load-systemko.service - Load System Modules.
          Starting sensor-config.service - Configure Sensor...
 [  OK  ] Finished sensor-config.service - Configure Sensor.
@@ -70,42 +68,37 @@ The system booted successfully, and login via the serial port was also successfu
          Starting enable-backlight.service - Enable backlight...
 [  OK  ] Finished enable-backlight.service - Enable backlight.
          Starting load-fb.service - Load fb...
-[  OK  ] Started systemd-hostnamed.service - Hostname Service.
 [  OK  ] Finished load-fb.service - Load fb.
          Starting load-tp.service - Load tp...
-         Starting NetworkManager-dispatcher…anager Script Dispatcher Service...
-[  OK  ] Started NetworkManager.service - Network Manager.
 [  OK  ] Finished load-tp.service - Load tp.
          Starting device-uuid.service - Set MAC address...
-[  OK  ] Started NetworkManager-dispatcher.… Manager Script Dispatcher Service.
 [  OK  ] Finished device-uuid.service - Set MAC address.
          Starting load-wifimod.service - Load wifimod...
-[  OK  ] Finished e2scrub_reap.service - Re…line ext4 Metadata Check Snapshots.
+[  OK  ] Started systemd-hostnamed.service - Hostname Service.
+         Starting NetworkManager-dispatcher…anager Script Dispatcher Service...
+[  OK  ] Started NetworkManager.service - Network Manager.
+[  OK  ] Started NetworkManager-dispatcher.… Manager Script Dispatcher Service.
 [  OK  ] Finished load-wifimod.service - Load wifimod.
-[  OK  ] Finished finalize-image.service - Finalize the Image.
          Starting gadget-nic.service - Start Gadget NIC...
 [  OK  ] Started ifup@end0.service - ifup for end0.
 [  OK  ] Finished gadget-nic.service - Start Gadget NIC.
 [  OK  ] Reached target network.target - Network.
          Starting gadget-nic-usb0.service - USB NIC DHCP Gadget Support...
          Starting lldpd.service - LLDP daemon...
-         Starting ssh.service - OpenBSD Secure Shell server...
          Starting systemd-user-sessions.service - Permit User Sessions...
 [  OK  ] Started gadget-nic-usb0.service - USB NIC DHCP Gadget Support.
 [  OK  ] Finished systemd-user-sessions.service - Permit User Sessions.
 [  OK  ] Started getty@tty1.service - Getty on tty1.
 [  OK  ] Started serial-getty@ttyS0.service - Serial Getty on ttyS0.
 [  OK  ] Reached target getty.target - Login Prompts.
+[  OK  ] Finished e2scrub_reap.service - Re…line ext4 Metadata Check Snapshots.
 [  OK  ] Started lldpd.service - LLDP daemon.
-[  OK  ] Started ssh.service - OpenBSD Secure Shell server.
-[  OK  ] Reached target multi-user.target - Multi-User System.
-[  OK  ] Reached target graphical.target - Graphical Interface.
 
-Debian GNU/Linux trixie/sid duo256-b327 ttyS0
+Debian GNU/Linux 13 duo256-22ef ttyS0
 
-duo256-b327 login: root
+duo256-22ef login: debian
 Password:
-Linux duo256-b327 5.10.235-20250403-6+duo256 #1 PREEMPT Sat Apr 5 17:40:54 UTC 2025 riscv64
+Linux duo256-22ef 5.10.235-20250430-6+duo256 #1 PREEMPT Sun May 25 13:35:00 UTC 2025 riscv64
 
 The programs included with the Debian GNU/Linux system are free software;
 the exact distribution terms for each program are described in the
@@ -113,29 +106,27 @@ individual files in /usr/share/doc/*/copyright.
 
 Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
 permitted by applicable law.
-root@duo256-b327:~# uname -a
-Linux duo256-b327 5.10.235-20250403-6+duo256 #1 PREEMPT Sat Apr 5 17:40:54 UTC 2025 riscv64 GNU/Linux
-root@duo256-b327:~# cat /etc/os-release
-PRETTY_NAME="Debian GNU/Linux trixie/sid"
+
+debian@duo256-22ef:~$ uname -a
+Linux duo256-22ef 5.10.235-20250430-6+duo256 #1 PREEMPT Sun May 25 13:35:00 UTC 2025 riscv64 GNU/Linux
+
+debian@duo256-22ef:~$ cat /etc/os-release
+PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
 NAME="Debian GNU/Linux"
+VERSION_ID="13"
+VERSION="13 (trixie)"
 VERSION_CODENAME=trixie
+DEBIAN_VERSION_FULL=13.0
 ID=debian
 HOME_URL="https://www.debian.org/"
 SUPPORT_URL="https://www.debian.org/support"
 BUG_REPORT_URL="https://bugs.debian.org/"
-root@duo256-b327:~# lscpu
-Architecture:          riscv64
-  Byte Order:          Little Endian
-CPU(s):                1
-  On-line CPU(s) list: 0
-root@duo256-b327:~# cat /proc/cpuinfo
+
+debian@duo256-22ef:~$ cat /proc/cpuinfo
 processor       : 0
 hart            : 0
 isa             : rv64imafdvcsu
 mmu             : sv39
-
-root@duo256-b327:~#
-
 ```
 
 ## Test Criteria
@@ -147,4 +138,3 @@ Failed: The actual result does not match the expected result.
 ## Test Conclusion
 
 Test successful.
-

--- a/Duo256m/Debian/README_zh.md
+++ b/Duo256m/Debian/README_zh.md
@@ -4,11 +4,12 @@
 
 ### 操作系统信息
 
-- 系统版本：Debian
-- 下载链接：https://github.com/scpcom/sophgo-sg200x-debian/releases/download/v1.6.7/duo256-e_sd.img.lz4
-- 参考安装文档：https://github.com/scpcom/sophgo-sg200x-debian/
+- 系统版本：Debian 13.0
+- 下载链接：<https://github.com/scpcom/sophgo-sg200x-debian/releases/download/v1.6.23/duo256-e_sd.img.lz4>
+- 参考安装文档：<https://github.com/scpcom/sophgo-sg200x-debian/>
 
-> Note: 此镜像为社区开发者提供，非官方镜像。
+> [!Note]
+> 此镜像为社区开发者提供，非官方镜像。
 
 ### 硬件信息
 
@@ -23,7 +24,7 @@
 ### 使用 `dd` 刷写镜像到 microSD 卡
 
 ```shell
-wget https://github.com/scpcom/sophgo-sg200x-debian/releases/download/v1.6.7/duo256-e_sd.img.lz4
+wget https://github.com/scpcom/sophgo-sg200x-debian/releases/download/v1.6.23/duo256-e_sd.img.lz4
 lz4 -d duo256-e_sd.img.lz4
 sudo dd if=duo256-e_sd.img of=/dev/your/device bs=1M status=progress
 ```
@@ -33,6 +34,7 @@ sudo dd if=duo256-e_sd.img of=/dev/your/device bs=1M status=progress
 通过串口登录系统。
 
 用户名：`root`
+
 密码：`rv`
 
 ## 预期结果
@@ -46,11 +48,7 @@ sudo dd if=duo256-e_sd.img of=/dev/your/device bs=1M status=progress
 ### 启动信息
 
 ```log
-[   21.658971] RTOS_CMDQU_SEND_WAIT timeout
-[   21.666545] SYS_CMD_INFO_LINUX_INIT_DONE fail
-[   21.695036] communicate with rtos fail
-         Starting systemd-hostnamed.service - Hostname Service...
-[  OK  ] Started systemd-logind.service - User Login Management.
+[   25.075962] communicate with rtos fail
 [  OK  ] Finished load-systemko.service - Load System Modules.
          Starting sensor-config.service - Configure Sensor...
 [  OK  ] Finished sensor-config.service - Configure Sensor.
@@ -61,42 +59,37 @@ sudo dd if=duo256-e_sd.img of=/dev/your/device bs=1M status=progress
          Starting enable-backlight.service - Enable backlight...
 [  OK  ] Finished enable-backlight.service - Enable backlight.
          Starting load-fb.service - Load fb...
-[  OK  ] Started systemd-hostnamed.service - Hostname Service.
 [  OK  ] Finished load-fb.service - Load fb.
          Starting load-tp.service - Load tp...
-         Starting NetworkManager-dispatcher…anager Script Dispatcher Service...
-[  OK  ] Started NetworkManager.service - Network Manager.
 [  OK  ] Finished load-tp.service - Load tp.
          Starting device-uuid.service - Set MAC address...
-[  OK  ] Started NetworkManager-dispatcher.… Manager Script Dispatcher Service.
 [  OK  ] Finished device-uuid.service - Set MAC address.
          Starting load-wifimod.service - Load wifimod...
-[  OK  ] Finished e2scrub_reap.service - Re…line ext4 Metadata Check Snapshots.
+[  OK  ] Started systemd-hostnamed.service - Hostname Service.
+         Starting NetworkManager-dispatcher…anager Script Dispatcher Service...
+[  OK  ] Started NetworkManager.service - Network Manager.
+[  OK  ] Started NetworkManager-dispatcher.… Manager Script Dispatcher Service.
 [  OK  ] Finished load-wifimod.service - Load wifimod.
-[  OK  ] Finished finalize-image.service - Finalize the Image.
          Starting gadget-nic.service - Start Gadget NIC...
 [  OK  ] Started ifup@end0.service - ifup for end0.
 [  OK  ] Finished gadget-nic.service - Start Gadget NIC.
 [  OK  ] Reached target network.target - Network.
          Starting gadget-nic-usb0.service - USB NIC DHCP Gadget Support...
          Starting lldpd.service - LLDP daemon...
-         Starting ssh.service - OpenBSD Secure Shell server...
          Starting systemd-user-sessions.service - Permit User Sessions...
 [  OK  ] Started gadget-nic-usb0.service - USB NIC DHCP Gadget Support.
 [  OK  ] Finished systemd-user-sessions.service - Permit User Sessions.
 [  OK  ] Started getty@tty1.service - Getty on tty1.
 [  OK  ] Started serial-getty@ttyS0.service - Serial Getty on ttyS0.
 [  OK  ] Reached target getty.target - Login Prompts.
+[  OK  ] Finished e2scrub_reap.service - Re…line ext4 Metadata Check Snapshots.
 [  OK  ] Started lldpd.service - LLDP daemon.
-[  OK  ] Started ssh.service - OpenBSD Secure Shell server.
-[  OK  ] Reached target multi-user.target - Multi-User System.
-[  OK  ] Reached target graphical.target - Graphical Interface.
 
-Debian GNU/Linux trixie/sid duo256-b327 ttyS0
+Debian GNU/Linux 13 duo256-22ef ttyS0
 
-duo256-b327 login: root
+duo256-22ef login: debian
 Password:
-Linux duo256-b327 5.10.235-20250403-6+duo256 #1 PREEMPT Sat Apr 5 17:40:54 UTC 2025 riscv64
+Linux duo256-22ef 5.10.235-20250430-6+duo256 #1 PREEMPT Sun May 25 13:35:00 UTC 2025 riscv64
 
 The programs included with the Debian GNU/Linux system are free software;
 the exact distribution terms for each program are described in the
@@ -104,31 +97,28 @@ individual files in /usr/share/doc/*/copyright.
 
 Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
 permitted by applicable law.
-root@duo256-b327:~# uname -a
-Linux duo256-b327 5.10.235-20250403-6+duo256 #1 PREEMPT Sat Apr 5 17:40:54 UTC 2025 riscv64 GNU/Linux
-root@duo256-b327:~# cat /etc/os-release
-PRETTY_NAME="Debian GNU/Linux trixie/sid"
+
+debian@duo256-22ef:~$ uname -a
+Linux duo256-22ef 5.10.235-20250430-6+duo256 #1 PREEMPT Sun May 25 13:35:00 UTC 2025 riscv64 GNU/Linux
+
+debian@duo256-22ef:~$ cat /etc/os-release
+PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
 NAME="Debian GNU/Linux"
+VERSION_ID="13"
+VERSION="13 (trixie)"
 VERSION_CODENAME=trixie
+DEBIAN_VERSION_FULL=13.0
 ID=debian
 HOME_URL="https://www.debian.org/"
 SUPPORT_URL="https://www.debian.org/support"
 BUG_REPORT_URL="https://bugs.debian.org/"
-root@duo256-b327:~# lscpu
-Architecture:          riscv64
-  Byte Order:          Little Endian
-CPU(s):                1
-  On-line CPU(s) list: 0
-root@duo256-b327:~# cat /proc/cpuinfo
+
+debian@duo256-22ef:~$ cat /proc/cpuinfo
 processor       : 0
 hart            : 0
 isa             : rv64imafdvcsu
 mmu             : sv39
-
-root@duo256-b327:~#
-
 ```
-
 
 ## 测试判定标准
 

--- a/Duo256m/README.md
+++ b/Duo256m/README.md
@@ -16,9 +16,9 @@ ram: 256MB
   - Download link: [https://github.com/milkv-duo/duo-buildroot-sdk/releases](https://github.com/milkv-duo/duo-buildroot-sdk/releases)
     - Official Milk-V provided BuildRoot SDK, which also includes FreeRTOS.
   - Reference Installation Document: [https://github.com/milkv-duo/duo-buildroot-sdk](https://github.com/milkv-duo/duo-buildroot-sdk)
-- Debian
-  - Download link: https://github.com/scpcom/sophgo-sg200x-debian/releases/download/v1.6.7/duo256-e_sd.img.lz4
-  - Reference Installation Document: https://github.com/scpcom/sophgo-sg200x-debian/
+- Debian 13.0
+  - Download link: <https://github.com/scpcom/sophgo-sg200x-debian/releases/download/v1.6.23/duo256-e_sd.img.lz4>
+  - Reference Installation Document: <https://github.com/scpcom/sophgo-sg200x-debian/>
 - Fedora 41
   - Download Link: https://mirror.iscas.ac.cn/fedora-riscv/dl/Milk-V/Duo256M/images/latest/milkv-duo-256m-fedora-minimal.img.gz
   - Reference Installation Document: https://github.com/chainsx/fedora-riscv-builder
@@ -74,9 +74,9 @@ ram: 256MB
 | RT-Thread Image Build & Boot       | N/A          | [Success][RT-Thread]                                             |
 | RT-Thread Smart Image Build & Boot | N/A          | [Success][RT-Smart]                                              |
 | Zephyr Image Build & Boot          | N/A          | [Success][Zephyr]                                                |
-| xv6 Image Boot                     | N/A          | [Failed][Zephyr]                                                 |
+| xv6 Image Boot                     | N/A          | [Failed][xv6]                                                 |
 | Alpine Linux Boot                  | N/A          | [Success][Alpine] (use community image or build rootfs manually) |
-| Ubuntu Boot                        | N/A          | [Success][Alpine] (use community image or build rootfs manually) |
+| Ubuntu Boot                        | N/A          | [Success][Ubuntu] (use community image or build rootfs manually) |
 | Yocto Image Build and Boot         | N/A          | [Success][Yocto]                                                 |
 | NixOS Image Build and Boot         | N/A          | [Success][NixOS]                                                 |
 

--- a/Duo256m/README_zh.md
+++ b/Duo256m/README_zh.md
@@ -8,9 +8,9 @@
   - 下载链接：https://github.com/milkv-duo/duo-buildroot-sdk/releases
     - Milk-V 官方提供的 BuildRoot SDK，同时包含了 FreeRTOS
   - 参考安装文档：https://github.com/milkv-duo/duo-buildroot-sdk
-- Debian
-  - 下载链接：https://github.com/scpcom/sophgo-sg200x-debian/releases/download/v1.6.7/duo256-e_sd.img.lz4
-  - 参考安装文档：https://github.com/scpcom/sophgo-sg200x-debian/
+- Debian 13.0
+  - 下载链接：<https://github.com/scpcom/sophgo-sg200x-debian/releases/download/v1.6.23/duo256-e_sd.img.lz4>
+  - 参考安装文档：<https://github.com/scpcom/sophgo-sg200x-debian/>
 - Fedora 41
   - 下载链接：https://mirror.iscas.ac.cn/fedora-riscv/dl/Milk-V/Duo256M/images/latest/milkv-duo-256m-fedora-minimal.img.gz
   - 参考安装文档：https://github.com/chainsx/fedora-riscv-builder
@@ -64,7 +64,7 @@
 | Debian 镜像启动                | N/A      | [成功][Debian]                                     |
 | Fedora 镜像启动                | N/A      | [成功][Fedora]                                     |
 | RT-Thread 镜像构建及启动       | N/A      | [成功][RT-Thread]                                  |
-| RT-Thread Smart 镜像构建及启动 | N/A      | [成功][RT-Thread]                                  |
+| RT-Thread Smart 镜像构建及启动 | N/A      | [成功][RT-Smart]                                  |
 | Zephyr 镜像构建及启动          | N/A      | [成功][Zephyr]                                     |
 | xv6 镜像启动                   | N/A      | [失败][xv6]                                        |
 | Alpine Linux 启动              | N/A      | [成功][Alpine] （可使用社区镜像或手工构建 rootfs） |


### PR DESCRIPTION
# Welcome to Pull Request

Thank you for your contribution! Please refer to the [contributing guidelines](../CONTRIBUTING.md) for more details.

## If you are working on the support-matrix report

We appreciate your effort in improving the support matrix. To generate the SVG image locally, you can use:

```sh
python assets/generate_svgimage.py -p . -o assets/output --html https://${{ github.repository_owner }}.github.io/support-matrix
```

For internationalization (i18n) SVG generation  test, simply add the `-l zh` option.

If you're creating a new report, please refer to our templates:
- [Board report template](../report-template/[board-name]/README.md)
- [OS report template](../report-template/[board-name]/[os-name]/README.md)

### Checklist
- [x] SVG table generation passes successfully
- [x] Appropriate changes to documentation are included in the PR
- [x] i18n for documentation (optional)