### PR TITLE
LiP4A: Fix broken download links

### DIFF
--- a/LicheePi4A/Deepin/README.md
+++ b/LicheePi4A/Deepin/README.md
@@ -14,7 +14,7 @@ last_update: 2025-01-24
 ### System Information
 
 - System Version: Deepin 25-beige-preview 20250122
-- Download Link: https://deepin-community.github.io/sig-deepin-ports/images/riscv/download
+- Download Link: https://ci.deepin.com/repo/deepin/deepin-ports/cdimage/20250122/riscv64/deepin-25-beige-preview-riscv64-th1520-20250122-113934.tar.xz
 - Reference Installation Document: https://cdimage.deepin.com/RISC-V/preview-20240517-riscv64/README.md
 
 ### Hardware Information
@@ -45,7 +45,7 @@ tar -xvf deepin-25-beige-preview-riscv64-th1520-20250122-113934.tar.xz
 sudo fastboot flash ram u-boot-with-spl.bin
 sudo fastboot reboot
 sudo fastboot flash uboot u-boot-with-spl.bin
-sudo fastboot flash boot deepin-th1520-riscv64-25-desktop-installer.boot.ext4 
+sudo fastboot flash boot deepin-th1520-riscv64-25-desktop-installer.boot.ext4
 ```
 
 ### Flashing the Image
@@ -53,7 +53,7 @@ sudo fastboot flash boot deepin-th1520-riscv64-25-desktop-installer.boot.ext4
 Flash the root partition into the eMMC.
 
 ```bash
-sudo fastboot flash root deepin-th1520-riscv64-25-desktop-installer.root.ext4 
+sudo fastboot flash root deepin-th1520-riscv64-25-desktop-installer.root.ext4
 ```
 
 ### Logging into the System
@@ -98,7 +98,7 @@ HOME_URL="https://www.deepin.org/"
 BUG_REPORT_URL="https://bbs.deepin.org"
 VERSION_ID="25"
 VERSION="25"
-root@plct-PC:~# cat /proc/cpuinfo 
+root@plct-PC:~# cat /proc/cpuinfo
 processor       : 0
 hart            : 0
 isa             : rv64imafdcvsu

--- a/LicheePi4A/Deepin/README_zh.md
+++ b/LicheePi4A/Deepin/README_zh.md
@@ -5,7 +5,7 @@
 ### 系统信息
 
 - 系统版本：Deepin 25-beige-preview 20250122
-- 下载链接：https://deepin-community.github.io/sig-deepin-ports/images/riscv/download
+- 下载链接：https://ci.deepin.com/repo/deepin/deepin-ports/cdimage/20250122/riscv64/deepin-25-beige-preview-riscv64-th1520-20250122-113934.tar.xz
 - 参考安装文档：https://cdimage.deepin.com/RISC-V/preview-20240517-riscv64/README.md
 
 ### 硬件信息
@@ -36,7 +36,7 @@ tar -xvf deepin-25-beige-preview-riscv64-th1520-20250122-113934.tar.xz
 sudo fastboot flash ram u-boot-with-spl.bin
 sudo fastboot reboot
 sudo fastboot flash uboot u-boot-with-spl.bin
-sudo fastboot flash boot deepin-th1520-riscv64-25-desktop-installer.boot.ext4 
+sudo fastboot flash boot deepin-th1520-riscv64-25-desktop-installer.boot.ext4
 ```
 
 ### 刷写镜像
@@ -44,7 +44,7 @@ sudo fastboot flash boot deepin-th1520-riscv64-25-desktop-installer.boot.ext4
 将 root 分区刷入 eMMC 中。
 
 ```bash
-sudo fastboot flash root deepin-th1520-riscv64-25-desktop-installer.root.ext4 
+sudo fastboot flash root deepin-th1520-riscv64-25-desktop-installer.root.ext4
 ```
 
 ### 登录系统
@@ -89,7 +89,7 @@ HOME_URL="https://www.deepin.org/"
 BUG_REPORT_URL="https://bbs.deepin.org"
 VERSION_ID="25"
 VERSION="25"
-root@plct-PC:~# cat /proc/cpuinfo 
+root@plct-PC:~# cat /proc/cpuinfo
 processor       : 0
 hart            : 0
 isa             : rv64imafdcvsu
@@ -138,7 +138,7 @@ cpu-tlb         : 1024 4-ways
 cpu-cacheline   : 64Bytes
 cpu-vector      : 0.7.1
 
-root@plct-PC:~# 
+root@plct-PC:~#
 ```
 
 ![](./image.png)

--- a/LicheePi4A/README.md
+++ b/LicheePi4A/README.md
@@ -42,7 +42,7 @@ cpu_arch: [
     - Download link: https://mirror.iscas.ac.cn/archriscv/images/
     - Reference Installation Document: https://wiki.archlinux.org/title/General_recommendations
 - Deepin 25-beige-preview 20250122
-    - Download Link: https://deepin-community.github.io/sig-deepin-ports/images/riscv/download
+    - Download Link: https://ci.deepin.com/repo/deepin/deepin-ports/cdimage/20250122/riscv64/deepin-25-beige-preview-riscv64-th1520-20250122-113934.tar.xz
     - Reference Installation Document: https://cdimage.deepin.com/RISC-V/preview-20240517-riscv64/README.md
 - NixOS 23.05
     - Download Link：https://github.com/ryan4yin/nixos-licheepi4a/releases


### PR DESCRIPTION
# Welcome to Pull Request

Thank you for your contribution! Please refer to the [contributing guidelines](../CONTRIBUTING.md) for more details.

## If you are working on the support-matrix report

We appreciate your effort in improving the support matrix. To generate the SVG image locally, you can use:

```sh
python assets/generate_svgimage.py -p . -o assets/output --html https://${{ github.repository_owner }}.github.io/support-matrix
```

For internationalization (i18n) SVG generation  test, simply add the `-l zh` option.

If you're creating a new report, please refer to our templates:
- [Board report template](../report-template/[board-name]/README.md)
- [OS report template](../report-template/[board-name]/[os-name]/README.md)

### Checklist
- [X] SVG table generation passes successfully
- [X] Appropriate changes to documentation are included in the PR
- [X] i18n for documentation (optional)

This PR fixes broken download links of Deepin@LiP4A