### PR TITLE
Duo: Bump Buildroot to v2.0.1

### DIFF
--- a/Duo/BuildRoot/README_v2.md
+++ b/Duo/BuildRoot/README_v2.md
@@ -1,46 +1,60 @@
 ---
 sys: buildroot
-sys_ver: v2.0.0
+sys_ver: v2.0.1
 sys_var: v2
 
 status: basic
-last_update: 2025-04-07
+last_update: 2025-08-22
 ---
 
-# BuildRoot (v2) Milk-V Duo Test Report
+# Buildroot (v2) Milk-V Duo Test Report
 
 ## Test Environment
 
 ### Operating System Information
-
-- System Version: Duo-V2.0.0
-- Download Link: https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases
-- Reference Installation Document: https://github.com/milkv-duo/duo-buildroot-sdk-v2
+- System Version: Duo Buildroot V2.0.1
+- Download Link: <https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases/download/v2.0.1/milkv-duo-musl-riscv64-sd_v2.0.1.img.zip>
+- Reference Installation Document: <https://github.com/milkv-duo/duo-buildroot-sdk-v2>
 
 ### Hardware Information
-
 - Milk-V Duo 64M
-- A USB-A to C or USB C to C cable
-- A microSD card
+- USB to UART debugger
+- microSD card
 
 ## Installation Steps
 
-### Using `dd` to Flash the Image to the microSD Card
-
+### Download and Extract Image
+Download the desired image from the [download link](https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases/download/v2.0.1/milkv-duo-musl-riscv64-sd_v2.0.1.img.zip).
+**Extract files:**
 ```shell
-sudo dd if=milkv-duo-musl-riscv64-sd_v2.0.0.img  of=/path/to/your/device bs=4M status=progress
+unzip milkv-duo-musl-riscv64-sd_v2.0.1.img.zip
 ```
 
-### Logging into the System
+### Using `dd` to Flash the Image to the microSD Card
+```shell
+sudo dd if=milkv-duo-musl-riscv64-sd_v2.0.1.img of=/dev/mmcblkX bs=1M
+```
 
-Logging into the system via serial port or SSH.
+Log:
+```log
+输入了 896+1 块记录
+输出了 896+1 块记录
+939524608 字节 (940 MB, 896 MiB) 已复制，31.3784 s，29.9 MB/s
+```
+
+## Logging into the System
+Insert the microSD card into Milk-V Duo and reboot.
+Use a serial connection to log in; e.g. `minicom`.
+```bash
+minicom -D /dev/ttyACM0 -c on
+```
 
 Default username: `root`
-Default password: none
+Default password: `milkv`
 
 ## Expected Results
-
-The system boots up normally and allows login through the onboard serial port.
+System boots normally and allows login via onboard serial port.
+If USB NET is connected, SSH login should also work.
 
 ## Actual Results
 
@@ -49,36 +63,39 @@ The system booted successfully and login via the onboard serial port was also su
 ### Boot Log
 
 ```log
-[    2.892411] vi_core_probe:206(): irq(33) for isp get from platform driver.
-[    2.901240] sync_task_init:177(): sync_task_init vi_pipe 0
-[    2.906979] sync_task_init:177(): sync_task_init vi_pipe 1
-[    2.913081] sync_task_init:177(): sync_task_init vi_pipe 2
-[    2.919041] sync_task_init:177(): sync_task_init vi_pipe 3
-[    2.924997] sync_task_init:177(): sync_task_init vi_pipe 4
-[    2.931494] vi_core_probe:242(): isp registered as cvi-vi
-[    2.986778] vpss_start_handler:5134(): handler for dev(0) started
-[    2.986970] vpss_start_handler:5134(): handler for dev(1) started
-[    3.027421] cv180x-cooling cv180x_cooling: elems of dev-freqs=6
-[    3.040112] cv180x-cooling cv180x_cooling: dev_freqs[0]: 850000000 500000000
-[    3.048032] cv180x-cooling cv180x_cooling: dev_freqs[1]: 425000000 375000000
-[    3.055656] cv180x-cooling cv180x_cooling: dev_freqs[2]: 425000000 300000000
-[    3.063401] cv180x-cooling cv180x_cooling: Cooling device registered: cv180x_cooling
-[    3.093205] [INFO] Register SBM IRQ ###################################
-[    3.093235] [INFO] pvctx->s_sbm_irq = 38
-[    3.108700] jpu ctrl reg pa = 0xb030000, va = (____ptrval____), size = 256
-[    3.121295] end jpu_init result = 0x0
-[    3.206886] cvi_vc_drv_init result = 0x0
-[    3.220299] sh (163): drop_caches: 3
+[    2.777741] sync_task_init:177(): sync_task_init vi_pipe 2
+[    2.783716] sync_task_init:177(): sync_task_init vi_pipe 3
+[    2.789690] sync_task_init:177(): sync_task_init vi_pipe 4
+[    2.796187] vi_core_probe:242(): isp registered as cvi-vi
+[    2.854730] vpss_start_handler:5143(): handler for dev(0) started
+[    2.854911] vpss_start_handler:5143(): handler for dev(1) started
+[    2.905199] cv180x-cooling cv180x_cooling: elems of dev-freqs=6
+[    2.917803] cv180x-cooling cv180x_cooling: dev_freqs[0]: 850000000 500000000
+[    2.925703] cv180x-cooling cv180x_cooling: dev_freqs[1]: 425000000 375000000
+[    2.933317] cv180x-cooling cv180x_cooling: dev_freqs[2]: 425000000 300000000
+[    2.941032] cv180x-cooling cv180x_cooling: Cooling device registered: cv180x_cooling
+[    2.975689] [INFO] Register SBM IRQ ###################################
+[    2.975718] [INFO] pvctx->s_sbm_irq = 38
+[    2.996176] jpu ctrl reg pa = 0xb030000, va = (____ptrval____), size = 256
+[    3.007900] end jpu_init result = 0x0
+[    3.101127] cvi_vc_drv_init result = 0x0
+[    3.115999] sh (167): drop_caches: 3
 Starting app...
 
 [root@milkv-duo]~# uname -a
-Linux milkv-duo 5.10.4-tag- #1 PREEMPT Mon Dec 9 10:07:12 CST 2024 riscv64 GNU/Linux
+Linux milkv-duo 5.10.4-tag- #1 PREEMPT Fri May 30 14:51:52 CST 2025 riscv64 GNU/Linux
+[root@milkv-duo]~# cat /proc/cpuinfo
+processor       : 0
+hart            : 0
+isa             : rv64imafdvcsu
+mmu             : sv39
+
 [root@milkv-duo]~# cat /etc/os-release
 NAME=Buildroot
-VERSION=-g2b4e5fdbc
+VERSION=-g6b03c2762-dirty
 ID=buildroot
-VERSION_ID=2024.02.3
-PRETTY_NAME="Buildroot 2024.02.3"
+VERSION_ID=2025.02
+PRETTY_NAME="Buildroot 2025.02"
 [root@milkv-duo]~#
 ```
 

--- a/Duo/BuildRoot/README_v2_zh.md
+++ b/Duo/BuildRoot/README_v2_zh.md
@@ -1,72 +1,93 @@
-# BuildRoot (v2) Milk-V Duo 测试报告
+# Buildroot (v2) Milk-V Duo 测试报告
 
 ## 测试环境
 
 ### 操作系统信息
 
-- 系统版本：Duo-V2.0.0
-- 下载链接：https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases
-- 参考安装文档：https://github.com/milkv-duo/duo-buildroot-sdk-v2
+- 系统版本：Duo Buildroot V2.0.1
+- 下载链接：<https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases/download/v2.0.1/milkv-duo-musl-riscv64-sd_v2.0.1.img.zip>
+- 参考安装文档：<https://github.com/milkv-duo/duo-buildroot-sdk-v2>
 
 ### 硬件信息
 
 - Milk-V Duo 64M
-- USB-A to C 或 USB C to C 线缆一条
-- microSD 卡一张
+- USB 转 UART 调试器
+- microSD 卡
 
 ## 安装步骤
 
-### 使用 `dd` 刷写镜像到 microSD 卡
-
+### 下载并解压镜像
+从[下载链接](https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases/download/v2.0.1/milkv-duo-musl-riscv64-sd_v2.0.1.img.zip)下载你所需镜像。
+**解压相关文件**
 ```shell
-sudo dd if=milkv-duo-musl-riscv64-sd_v2.0.0.img  of=/path/to/your/device bs=4M status=progress
+unzip milkv-duo-musl-riscv64-sd_v2.0.1.img.zip
+```
+
+### 向 microSD 卡烧录系统镜像
+可使用 `dd` 命令
+```shell
+sudo dd if=milkv-duo-musl-riscv64-sd_v2.0.1.img of=/dev/mmcblkX bs=1M
+```
+
+Log:
+```log
+输入了 896+1 块记录
+输出了 896+1 块记录
+939524608 字节 (940 MB, 896 MiB) 已复制，31.3784 s，29.9 MB/s
 ```
 
 ### 登录系统
+将 microSD 卡插入 Milk-V Duo，重启。
+通过串口登录系统，例如 `minicom` 工具。
+```bash
+minicom -D /dev/ttyACM0 -c on
+```
 
-通过串口或 ssh 登录系统。默认以 root 无密码登录。
+默认用户名：`root`
+默认密码：`milkv`
 
 ## 预期结果
-
 系统正常启动，能够通过板载串口登录。
+若 USB NET 已连接，可通过 SSH 登录。
 
 ## 实际结果
-
 系统正常启动，成功通过板载串口登录。
 
 ### 启动信息
-
 ```log
-[    2.892411] vi_core_probe:206(): irq(33) for isp get from platform driver.
-[    2.901240] sync_task_init:177(): sync_task_init vi_pipe 0
-[    2.906979] sync_task_init:177(): sync_task_init vi_pipe 1
-[    2.913081] sync_task_init:177(): sync_task_init vi_pipe 2
-[    2.919041] sync_task_init:177(): sync_task_init vi_pipe 3
-[    2.924997] sync_task_init:177(): sync_task_init vi_pipe 4
-[    2.931494] vi_core_probe:242(): isp registered as cvi-vi
-[    2.986778] vpss_start_handler:5134(): handler for dev(0) started
-[    2.986970] vpss_start_handler:5134(): handler for dev(1) started
-[    3.027421] cv180x-cooling cv180x_cooling: elems of dev-freqs=6
-[    3.040112] cv180x-cooling cv180x_cooling: dev_freqs[0]: 850000000 500000000
-[    3.048032] cv180x-cooling cv180x_cooling: dev_freqs[1]: 425000000 375000000
-[    3.055656] cv180x-cooling cv180x_cooling: dev_freqs[2]: 425000000 300000000
-[    3.063401] cv180x-cooling cv180x_cooling: Cooling device registered: cv180x_cooling
-[    3.093205] [INFO] Register SBM IRQ ###################################
-[    3.093235] [INFO] pvctx->s_sbm_irq = 38
-[    3.108700] jpu ctrl reg pa = 0xb030000, va = (____ptrval____), size = 256
-[    3.121295] end jpu_init result = 0x0
-[    3.206886] cvi_vc_drv_init result = 0x0
-[    3.220299] sh (163): drop_caches: 3
+[    2.777741] sync_task_init:177(): sync_task_init vi_pipe 2
+[    2.783716] sync_task_init:177(): sync_task_init vi_pipe 3
+[    2.789690] sync_task_init:177(): sync_task_init vi_pipe 4
+[    2.796187] vi_core_probe:242(): isp registered as cvi-vi
+[    2.854730] vpss_start_handler:5143(): handler for dev(0) started
+[    2.854911] vpss_start_handler:5143(): handler for dev(1) started
+[    2.905199] cv180x-cooling cv180x_cooling: elems of dev-freqs=6
+[    2.917803] cv180x-cooling cv180x_cooling: dev_freqs[0]: 850000000 500000000
+[    2.925703] cv180x-cooling cv180x_cooling: dev_freqs[1]: 425000000 375000000
+[    2.933317] cv180x-cooling cv180x_cooling: dev_freqs[2]: 425000000 300000000
+[    2.941032] cv180x-cooling cv180x_cooling: Cooling device registered: cv180x_cooling
+[    2.975689] [INFO] Register SBM IRQ ###################################
+[    2.975718] [INFO] pvctx->s_sbm_irq = 38
+[    2.996176] jpu ctrl reg pa = 0xb030000, va = (____ptrval____), size = 256
+[    3.007900] end jpu_init result = 0x0
+[    3.101127] cvi_vc_drv_init result = 0x0
+[    3.115999] sh (167): drop_caches: 3
 Starting app...
 
 [root@milkv-duo]~# uname -a
-Linux milkv-duo 5.10.4-tag- #1 PREEMPT Mon Dec 9 10:07:12 CST 2024 riscv64 GNU/Linux
+Linux milkv-duo 5.10.4-tag- #1 PREEMPT Fri May 30 14:51:52 CST 2025 riscv64 GNU/Linux
+[root@milkv-duo]~# cat /proc/cpuinfo
+processor       : 0
+hart            : 0
+isa             : rv64imafdvcsu
+mmu             : sv39
+
 [root@milkv-duo]~# cat /etc/os-release
 NAME=Buildroot
-VERSION=-g2b4e5fdbc
+VERSION=-g6b03c2762-dirty
 ID=buildroot
-VERSION_ID=2024.02.3
-PRETTY_NAME="Buildroot 2024.02.3"
+VERSION_ID=2025.02
+PRETTY_NAME="Buildroot 2025.02"
 [root@milkv-duo]~#
 ```
 


### PR DESCRIPTION
### Checklist
- [x] SVG table generation passes successfully
- [x] Appropriate changes to documentation are included in the PR
- [x] i18n for documentation (optional)

Issue #335 
