### PR TITLE
LicheePi4A: Bump RevyOS

### DIFF
--- a/LicheePi4A/RevyOS/README.md
+++ b/LicheePi4A/RevyOS/README.md
@@ -1,10 +1,10 @@
 ---
 sys: revyos
-sys_ver: "20250526"
+sys_ver: "20250930"
 sys_var: null
 
 status: good
-last_update: 2025-04-08
+last_update: 2025-10-29
 ---
 
 # RevyOS LPi4A Test Report
@@ -13,8 +13,8 @@ last_update: 2025-04-08
 
 ### System Information
 
-- System Version: RevyOS 20250526
-- Download Link: [Nginx Directory](https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250526/)
+- System Version: RevyOS 20250930
+- Download Link: [Nginx Directory](https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250930/)
 - Reference Installation Document: [Visit here](https://revyos.github.io/docs/)
 
 ### Hardware Information
@@ -30,11 +30,11 @@ last_update: 2025-04-08
 Download the image, use `zstd` to decompress the image:
 
 ```shell
-wget https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250526/u-boot-with-spl-lpi4a-16g-main.bin
-wget https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250526/boot-lpi4a-20250526_182059.ext4.zst
-wget https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250526/root-lpi4a-20250526_182059.ext4.zst
-zstd -d boot-lpi4a-20250526_182059.ext4.zst
-zstd -d root-lpi4a-20250526_182059.ext4.zst
+wget https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250930/u-boot-with-spl-lpi4a-16g-main.bin
+wget https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250930/boot-lpi4a-20250930_113443.ext4.zst
+wget https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250930/root-lpi4a-20250930_113443.ext4.zst
+zstd -d boot-lpi4a-20250930_113443.ext4.zst
+zstd -d root-lpi4a-20250930_113443.ext4.zst
 ```
 
 ### Flash to onboard eMMC via `fastboot`
@@ -50,8 +50,8 @@ sudo fastboot devices
 sudo fastboot flash ram u-boot-with-spl-lpi4a-16g-main.bin
 sudo fastboot reboot
 sudo fastboot flash uboot u-boot-with-spl-lpi4a-16g-main.bin
-sudo fastboot flash boot boot-lpi4a-20250526_182059.ext4.zst
-sudo fastboot flash root root-lpi4a-20250526_182059.ext4.zst
+sudo fastboot flash boot boot-lpi4a-20250930_113443.ext4.zst
+sudo fastboot flash root root-lpi4a-20250930_113443.ext4.zst
 ```
 
 ### Logging into the System
@@ -73,22 +73,22 @@ The system boots up successfully and login via the serial console is successful.
 
 Screen recording (from flashing image to logging into system):
 
-[![asciicast](https://asciinema.org/a/NI5udds5YK0GqgpJ0XVKop5tV.svg)](https://asciinema.org/a/NI5udds5YK0GqgpJ0XVKop5tV)
+[![asciicast](https://asciinema.org/a/EcUulslHiAdfr6lWrcUh87ItU.svg)](https://asciinema.org/a/EcUulslHiAdfr6lWrcUh87ItU)
 
 ![A](A.jpg)
 
 ```log
    ____              _ ____  ____  _  __
   |  _ \ _   _ _   _(_) ___||  _ \| |/ /
-  | |_) | | | | | | | \___ \| | | | ' / 
-  |  _ <| |_| | |_| | |___) | |_| | . \ 
+  | |_) | | | | | | | \___ \| | | | ' /
+  |  _ <| |_| | |_| | |___) | |_| | . \
   |_| \_\\__,_|\__, |_|____/|____/|_|\_\
-               |___/                    
+               |___/
                    -- Presented by ISCAS
 
-  Debian GNU/Linux trixie/sid (kernel 6.6.92-th1520)
+  Debian GNU/Linux trixie/sid (kernel 6.6.108-th1520)
 
-Linux revyos-lpi4a 6.6.92-th1520 #2025.05.26.14.02+c9a17b235 SMP Mon May 26 14:22:33 UTC 2025 riscv64
+Linux revyos-lpi4a 6.6.108-th1520 #2025.09.25.17.23+5c28a90d5 SMP Thu Sep 25 17:41:02 UTC 2025 riscv64
 
 The programs included with the Debian GNU/Linux system are free software;
 the exact distribution terms for each program are described in the
@@ -96,6 +96,7 @@ individual files in /usr/share/doc/*/copyright.
 
 Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
 permitted by applicable law.
+
 ```
 
 ## Test Criteria

--- a/LicheePi4A/RevyOS/README_zh.md
+++ b/LicheePi4A/RevyOS/README_zh.md
@@ -4,8 +4,8 @@
 
 ### 操作系统信息
 
-- 系统版本：RevyOS 20250526
-- 下载链接：[Nginx Directory](https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250526/)
+- 系统版本：RevyOS 20250930
+- 下载链接：[Nginx Directory](https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250930/)
 - 参考安装文档：https://revyos.github.io/docs/
 
 ### 硬件信息
@@ -21,11 +21,11 @@
 下载镜像，使用 `zstd` 解压镜像：
 
 ```shell
-wget https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250526/u-boot-with-spl-lpi4a-16g-main.bin
-wget https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250526/boot-lpi4a-20250526_182059.ext4.zst
-wget https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250526/root-lpi4a-20250526_182059.ext4.zst
-zstd -d boot-lpi4a-20250526_182059.ext4.zst
-zstd -d root-lpi4a-20250526_182059.ext4.zst
+wget https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250930/u-boot-with-spl-lpi4a-16g-main.bin
+wget https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250930/boot-lpi4a-20250930_113443.ext4.zst
+wget https://fast-mirror.isrc.ac.cn/revyos/extra/images/lpi4a/20250930/root-lpi4a-20250930_113443.ext4.zst
+zstd -d boot-lpi4a-20250930_113443.ext4.zst
+zstd -d root-lpi4a-20250930_113443.ext4.zst
 ```
 
 ### 通过 `fastboot` 刷写到板载 eMMC
@@ -41,8 +41,8 @@ sudo fastboot devices
 sudo fastboot flash ram u-boot-with-spl-lpi4a-16g-main.bin
 sudo fastboot reboot
 sudo fastboot flash uboot u-boot-with-spl-lpi4a-16g-main.bin
-sudo fastboot flash boot boot-lpi4a-20250526_182059.ext4.zst
-sudo fastboot flash root root-lpi4a-20250526_182059.ext4.zst
+sudo fastboot flash boot boot-lpi4a-20250930_113443.ext4.zst
+sudo fastboot flash root root-lpi4a-20250930_113443.ext4.zst
 ```
 
 ### 登录系统
@@ -64,22 +64,22 @@ sudo fastboot flash root root-lpi4a-20250526_182059.ext4.zst
 
 屏幕录制（从刷写镜像到登录系统）：
 
-[![asciicast](https://asciinema.org/a/NI5udds5YK0GqgpJ0XVKop5tV.svg)](https://asciinema.org/a/NI5udds5YK0GqgpJ0XVKop5tV)
+[![asciicast](https://asciinema.org/a/EcUulslHiAdfr6lWrcUh87ItU.svg)](https://asciinema.org/a/EcUulslHiAdfr6lWrcUh87ItU)
 
 ![A](A.jpg)
 
 ```log
    ____              _ ____  ____  _  __
   |  _ \ _   _ _   _(_) ___||  _ \| |/ /
-  | |_) | | | | | | | \___ \| | | | ' / 
-  |  _ <| |_| | |_| | |___) | |_| | . \ 
+  | |_) | | | | | | | \___ \| | | | ' /
+  |  _ <| |_| | |_| | |___) | |_| | . \
   |_| \_\\__,_|\__, |_|____/|____/|_|\_\
-               |___/                    
+               |___/
                    -- Presented by ISCAS
 
-  Debian GNU/Linux trixie/sid (kernel 6.6.92-th1520)
+  Debian GNU/Linux trixie/sid (kernel 6.6.108-th1520)
 
-Linux revyos-lpi4a 6.6.92-th1520 #2025.05.26.14.02+c9a17b235 SMP Mon May 26 14:22:33 UTC 2025 riscv64
+Linux revyos-lpi4a 6.6.108-th1520 #2025.09.25.17.23+5c28a90d5 SMP Thu Sep 25 17:41:02 UTC 2025 riscv64
 
 The programs included with the Debian GNU/Linux system are free software;
 the exact distribution terms for each program are described in the


### PR DESCRIPTION
# Welcome to Pull Request

Thank you for your contribution! Please refer to the [contributing guidelines](../CONTRIBUTING.md) for more details.

## If you are working on the support-matrix report

We appreciate your effort in improving the support matrix. To generate the SVG image locally, you can use:

```sh
python assets/generate_svgimage.py -p . -o assets/output --html https://${{ github.repository_owner }}.github.io/support-matrix
```

For internationalization (i18n) SVG generation  test, simply add the `-l zh` option.

If you're creating a new report, please refer to our templates:
- [Board report template](../report-template/[board-name]/README.md)
- [OS report template](../report-template/[board-name]/[os-name]/README.md)

### Checklist
- [X] SVG table generation passes successfully
- [X] Appropriate changes to documentation are included in the PR
- [X] i18n for documentation (optional)

## Summary by Sourcery

Update the RevyOS LPi4A test report to use the new 20250930 release

Documentation:
- Bump RevyOS version and last_update date in frontmatter to 20250930 and 2025-10-29
- Update system version labels, download URLs, and fastboot image filenames to the 20250930 release
- Refresh terminal recording link and kernel version/build timestamp in the boot log sample
- Mirror all updates in the Chinese README for consistency