### PR TITLE
docs(LicheeCluster4A): fix broken links in RevyOS report

### DIFF
--- a/LicheeCluster4A/RevyOS/README.md
+++ b/LicheeCluster4A/RevyOS/README.md
@@ -19,7 +19,7 @@ last_update: 2024-06-21
   - Boot Image: [boot-lpi4amain-20240127_105111.ext4.zst](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/boot-lpi4amain-20240127_105111.ext4.zst)
   - U-Boot Image (8G RAM): [u-boot-with-spl-lc4a-main.bin](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/u-boot-with-spl-lc4a-main.bin)
   - U-Boot Image (16G RAM): [u-boot-with-spl-lc4a-16g-main.bin](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/u-boot-with-spl-lc4a-16g-main.bin)
-- Reference Installation Document: https://revyos.github.io/
+- Reference Installation Document: https://revyos.github.io/docs/
 
 ### Hardware Information
 

--- a/LicheeCluster4A/RevyOS/README.md
+++ b/LicheeCluster4A/RevyOS/README.md
@@ -19,7 +19,7 @@ last_update: 2024-06-21
   - Boot Image: [boot-lpi4amain-20240127_105111.ext4.zst](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/boot-lpi4amain-20240127_105111.ext4.zst)
   - U-Boot Image (8G RAM): [u-boot-with-spl-lc4a-main.bin](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/u-boot-with-spl-lc4a-main.bin)
   - U-Boot Image (16G RAM): [u-boot-with-spl-lc4a-16g-main.bin](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/u-boot-with-spl-lc4a-16g-main.bin)
-- Reference Installation Document: https://revyos.github.io/docs/
+- Reference Installation Document: https://docs.revyos.dev
 
 ### Hardware Information
 

--- a/LicheeCluster4A/RevyOS/README_lpi4a.md
+++ b/LicheeCluster4A/RevyOS/README_lpi4a.md
@@ -14,7 +14,7 @@ last_update: 2024-06-21
 ### System Information
 
 - System Version: RevyOS
-- Reference Installation Document: https://revyos.github.io/docs/
+- Reference Installation Document: https://docs.revyos.dev
 
 ### Hardware Information
 

--- a/LicheeCluster4A/RevyOS/README_lpi4a.md
+++ b/LicheeCluster4A/RevyOS/README_lpi4a.md
@@ -14,7 +14,7 @@ last_update: 2024-06-21
 ### System Information
 
 - System Version: RevyOS
-- Reference Installation Document: [https://revyos.github.io/](https://revyos.github.io/)
+- Reference Installation Document: https://revyos.github.io/docs/
 
 ### Hardware Information
 

--- a/LicheeCluster4A/RevyOS/README_lpi4a_zh.md
+++ b/LicheeCluster4A/RevyOS/README_lpi4a_zh.md
@@ -5,7 +5,7 @@
 ### 操作系统信息
 
 - 系统版本：RevyOS
-- 参考安装文档：https://revyos.github.io/docs/
+- 参考安装文档：https://docs.revyos.dev
 
 ### 硬件信息
 

--- a/LicheeCluster4A/RevyOS/README_lpi4a_zh.md
+++ b/LicheeCluster4A/RevyOS/README_lpi4a_zh.md
@@ -5,7 +5,7 @@
 ### 操作系统信息
 
 - 系统版本：RevyOS
-- 参考安装文档：https://revyos.github.io/
+- 参考安装文档：https://revyos.github.io/docs/
 
 ### 硬件信息
 

--- a/LicheeCluster4A/RevyOS/README_zh.md
+++ b/LicheeCluster4A/RevyOS/README_zh.md
@@ -10,7 +10,7 @@
   - boot 镜像：[boot-lpi4amain-20240127_105111.ext4.zst](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/boot-lpi4amain-20240127_105111.ext4.zst)
   - u-boot 镜像（8G RAM）：[u-boot-with-spl-lc4a-main.bin](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/u-boot-with-spl-lc4a-main.bin)
   - u-boot 镜像（16G RAM）：[u-boot-with-spl-lc4a-16g-main.bin](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/u-boot-with-spl-lc4a-16g-main.bin)
-- 参考安装文档：https://revyos.github.io/docs/
+- 参考安装文档：https://docs.revyos.dev
 
 ### 硬件信息
 

--- a/LicheeCluster4A/RevyOS/README_zh.md
+++ b/LicheeCluster4A/RevyOS/README_zh.md
@@ -10,7 +10,7 @@
   - boot 镜像：[boot-lpi4amain-20240127_105111.ext4.zst](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/boot-lpi4amain-20240127_105111.ext4.zst)
   - u-boot 镜像（8G RAM）：[u-boot-with-spl-lc4a-main.bin](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/u-boot-with-spl-lc4a-main.bin)
   - u-boot 镜像（16G RAM）：[u-boot-with-spl-lc4a-16g-main.bin](https://mirror.iscas.ac.cn/revyos/extra/images/lpi4amain/20240127/u-boot-with-spl-lc4a-16g-main.bin)
-- 参考安装文档：https://revyos.github.io/
+- 参考安装文档：https://revyos.github.io/docs/
 
 ### 硬件信息
 


### PR DESCRIPTION
## Summary
Fixed 4 broken links in the documentation to ensure all references are accessible.

### Checklist
- [x] Appropriate changes to documentation are included in the PR

## Summary by Sourcery

Documentation:
- Correct reference installation document URLs in English and Chinese RevyOS README files for LicheeCluster4A.